### PR TITLE
Various extension vocab cleanup

### DIFF
--- a/src/extensions/biologicEntityExtension.ttl
+++ b/src/extensions/biologicEntityExtension.ttl
@@ -13,6 +13,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <https://schema.org/> .
 
 dct:created
   rdf:type owl:AnnotationProperty ;
@@ -33,97 +34,112 @@ bioe:
   rdf:type owl:Ontology ;
   rdfs:label "Basic taxon classes for biological entity."@en ;
   owl:imports <http://www.w3.org/2004/02/skos/core> ;
-  skos:definition "This is a vocabulary to categorize sampled organisms (whole or part) according to taxonomic classes. Classes are based largely on taxonomy found in Wikipedia, particularly Whittaker's five kingdom system (1969) (https://en.wikipedia.org/wiki/Kingdom_(biology), https://doi.org/10.1126%2Fscience.163.3863.150). The intended use is in iSamples cross domain categorization of material samples, recognizing that there are multiple view for taxonaomy and cladistist for the tree of life. This is a high level view intended for cross domain purposes, not expert analysis. Other extension vocablaries should be used for other taxonomic schemes"@en ;
+  skos:definition "This is a vocabulary to categorize sampled organisms (whole or part) according to taxonomic classes. Classes are based largely on taxonomy found in Wikipedia, particularly Whittaker's five kingdom system (1969). ChatGPT was used in some cases to determine what the distinguishing criteria are for some taxon classes. The intended use is in iSamples cross domain categorization of material samples, recognizing that there are multiple view for taxonaomy and cladistics for the tree of life. This is a high level view intended for cross domain purposes, not expert analysis. Other extension vocabularies should be used for other taxonomic schemes"@en ;
+    dct:source "https://en.wikipedia.org/wiki/Kingdom_(biology)";
+	dct:source "https://doi.org/10.1126%2Fscience.163.3863.150" ;
   skos:prefLabel "Basic taxon classes for biological entity."@en ;
+  schema:funding <AWDID:2004562>;
 .
+
+<AWDID:2004562> rdf:type schema:Grant;
+  schema:funder <https://ror.org/04nh1dc89>;
+  schema:name "Collaborative Research: Frameworks: Internet of Samples: Toward an Interdisciplinary Cyberinfrastructure for Material Samples";
+  schema:url   "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" 
+  .
+
 bioe:Animalia
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Animalia"@en ;
   skos:broader bioe:eukaryote ;
-  skos:definition """Animals are distinguished from other eukaryotes based on several key characteristics, including: 1) 
-animals are multicellular organisms 2) Animals are heterotrophic, they obtain their food by consuming other organisms or organic matter; 3) Animals lack cell walls; 4) Many animals have a nervous system; 5\\) Most animals reproduce sexually (Chat GPT)"""@en ;
+  skos:definition "Animals are distinguished from other eukaryotes based on several key characteristics, including: 1) animals are multicellular organisms 2) Animals are heterotrophic, they obtain their food by consuming other organisms or organic matter; 3) Animals lack cell walls; 4) Many animals have a nervous system; 5) Most animals reproduce sexually (Chat GPT)"@en ;
   skos:prefLabel "Animalia"@en ;
 .
 bioe:Fungi
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Fungi"@en ;
   skos:broader bioe:eukaryote ;
   skos:definition "eukaryotic organisms that contain chitin in their cell walls, are heterotrophs (they obtain their nutrients by absorbing organic material from their environment, either as decomposers, parasites, or symbionts) , lack chloroplasts, reproduce both sexually and asexually, and can take on a variety of growth forms, including single-celled yeasts, multicellular molds, and complex, specialized fruiting bodies. (ChatGPT)"@en ;
   skos:prefLabel "Fungi"@en ;
 .
 bioe:Plantae
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Plantae"@en ;
   skos:broader bioe:eukaryote ;
-  skos:definition "Plants are eukaryotes that have cell walls made of cellulose, specialized organelles called chloroplasts, which contain chlorophyll and other pigments that allow plants to perform photosynthesis and produce their own food;  a unique life cycle that involves alternating between a haploid gametophyte stage and a diploid sporophyte stage;  specialized regions called apical meristems at the tips of their roots and shoots, which allow for growth and the development of new tissues; specialized structures for reproduction, including flowers, cones, and spores, and most plants have specialized tissues called xylem and phloem, which transport water, nutrients, and other substances throughout the plant. (ChatGPT)"@en ;
+  skos:definition "Plants are eukaryotes with the following characteristics: cell walls made of cellulose;  specialized organelles called chloroplasts, which contain chlorophyll and other pigments that allow plants to perform photosynthesis and produce their own food;  a unique life cycle that involves alternating between a haploid gametophyte stage and a diploid sporophyte stage;  specialized regions called apical meristems at the tips of their roots and shoots, which allow for growth and the development of new tissues; specialized structures for reproduction, including flowers, cones, and spores, and most plants have specialized tissues called xylem and phloem, which transport water, nutrients, and other substances throughout the plant. (ChatGPT)"@en ;
   skos:prefLabel "Plantae"@en ;
 .
 bioe:Protista
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Protista"@en ;
   skos:broader bioe:eukaryote ;
   skos:definition "any organism whose cells contain a cell nucleus (a eucaryote) that is not an animal, plant, or fungus. (https://en.wikipedia.org/wiki/Protist).  Protista is not a specific taxonomic group, but a term that historically referred to a group of eukaryotic organisms that did not fit into the other kingdoms of plants, animals, and fungi. (ChatGPT)" ;
   skos:note "Alternate approach is to classify any unicellular eukaryotic microorganism as a protist." ;
+  dct:source "https://en.wikipedia.org/wiki/Protist";
   skos:prefLabel "Protista"@en ;
 .
 bioe:Vertebrate
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Vertebrate "@en ;
   skos:broader bioe:Animalia ;
   skos:definition "Animals that have a vertebral column, a cranium, an endoskeleton, a well-developed muscular system, and an advanced nervous system (ChatGPT);"@en ;
   skos:prefLabel "Vertebrate "@en ;
 .
 bioe:algae
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Algae"@en ;
   skos:broader bioe:eukaryote ;
-  skos:definition "informal term for a large and diverse group of photosynthetic eukaryotic organisms.  Included organisms range from unicellular microalgae, such as Chlorella, Prototheca and the diatoms, to multicellular forms, such as the giant kelp, a large brown alga which may grow up to 50 metres (160 ft) in length. Most are aquatic and autotrophic (they generate food internally) and lack many of the distinct cell and tissue types, such as stomata, xylem and phloem that are found in land plants.  Includes red algae (Rhodophycophyta), brown algae (Phaeophycophyta), and green algae (Chlorophycophyta). https://en.wikipedia.org/wiki/Algae"@en ;
+  skos:definition "informal term for a large and diverse group of photosynthetic eukaryotic organisms.  Included organisms range from unicellular microalgae, such as Chlorella, Prototheca and the diatoms, to multicellular forms, such as the giant kelp, a large brown alga which may grow up to 50 metres (160 ft) in length. Most are aquatic and autotrophic (they generate food internally) and lack many of the distinct cell and tissue types, such as stomata, xylem and phloem that are found in land plants.  Includes red algae (Rhodophycophyta), brown algae (Phaeophycophyta), and green algae (Chlorophycophyta)."@en ;
   skos:prefLabel "Algae"@en ;
+  dct:source "https://en.wikipedia.org/wiki/Algae";
   skos:related bioe:Plantae ;
   skos:related bioe:Protista ;
 .
 bioe:amoebozoa
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Amoebozoa  "@en ;
   skos:broader bioe:Protista ;
   skos:definition "a diverse group of organisms that share certain characteristics, such as the ability to move using pseudopodia, temporary extensions of the cell membrane and cytoplasm that allow the cell to crawl or engulf food particles, the lack of rigid cell walls, presence of mitochondria, which are organelles that generate energy for the cell through cellular respiration (chatGPT)"@en ;
   skos:prefLabel "Amoebozoa  "@en ;
 .
 bioe:amphibian
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Amphibian"@en ;
   skos:broader bioe:Vertebrate ;
   skos:definition "Vertebrates that have a dual life cycle, semi-permeable skin, absence of scales and claws, a three-chambered heart, and dependence on water for reproduction and survival (ChatGPT)"@en ;
   skos:prefLabel "Amphibian"@en ;
 .
 bioe:arachnid
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Arachnid"@en ;
   skos:broader bioe:arthropod ;
   skos:definition "a group of arthropods that share several key characteristics, including two main body segments, four pairs of legs, lack of antennae, simple eyes, and specialized feeding and defense structures called chelicerae (ChatGPT)"@en ;
   skos:prefLabel "Arachnid"@en ;
 .
 bioe:archaea
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Archaea"@en ;
   skos:altLabel "Archaebacteria" ;
   skos:broader bioe:prokaryote ;
-  skos:definition "archaeal cell walls are composed of polysaccharides (sugars). they never have peptidoglycan in their cell walls, their cell membranes contain lipids of unique composition (glycerol molecules are mirror images of those found in other cells, and form ether linkages to isoprenoid side chains), and their 16S ribosomal- RNA nucleotide sequences are unlike those of bacteria. (https://quizlet.com/234154298/archaea-and-bacteria-flash-cards/).  The common characteristics of Archaebacteria known to date are these: (1) the presence of characteristic tRNAs and ribosomal RNAs; (2) the absence of peptidoglycan cell walls, with in many cases, replacement by a largely proteinaceous coat; (3) the occurrence of ether linked lipids built from phytanyl chains and (4) in all cases known so far, their occurrence only in unusual habitats.  (https://pubmed.ncbi.nlm.nih.gov/691075/)"@en ;
+  skos:definition "archaea cell walls are composed of polysaccharides (sugars). they never have peptidoglycan in their cell walls, their cell membranes contain lipids of unique composition (glycerol molecules are mirror images of those found in other cells, and form ether linkages to isoprenoid side chains), and their 16S ribosomal- RNA nucleotide sequences are unlike those of bacteria. (https://quizlet.com/234154298/archaea-and-bacteria-flash-cards/).  The common characteristics of Archaebacteria known to date are these: (1) the presence of characteristic tRNAs and ribosomal RNAs; (2) the absence of peptidoglycan cell walls, with in many cases, replacement by a largely proteinaceous coat; (3) the occurrence of ether linked lipids built from phytanyl chains and (4) in all cases known so far, their occurrence only in unusual habitats.  (https://pubmed.ncbi.nlm.nih.gov/691075/)"@en ;
+  dct:source "https://quizlet.com/234154298/archaea-and-bacteria-flash-cards/";
+  dct:source "https://pubmed.ncbi.nlm.nih.gov/691075/";
   skos:prefLabel "Archaea"@en ;
 .
 bioe:arthropod
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Arthropod "@en ;
   skos:broader bioe:Animalia ;
-  skos:definition "invertebrate animals with an exoskeleton, a segmented body, and paired jointed appendages. Arthropods form the phylum Arthropoda. They are distinguished by their jointed limbs and cuticle made of chitin, often mineralised with calcium carbonate. The arthropod body plan consists of segments, each with a pair of appendages. Arthropods are bilaterally symmetrical and their body possesses an external skeleton. (https://en.wikipedia.org/wiki/Arthropod)"@en ;
+  skos:definition "invertebrate animals with an exoskeleton, a segmented body, and paired jointed appendages. Arthropods form the phylum Arthropoda. They are distinguished by their jointed limbs and cuticle made of chitin, often mineralised with calcium carbonate. The arthropod body plan consists of segments, each with a pair of appendages. Arthropods are bilaterally symmetrical and their body possesses an external skeleton."@en ;
+  dct:source "https://en.wikipedia.org/wiki/Arthropod";
   skos:prefLabel "Arthropod "@en ;
 .
 bioe:bacteria
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Bacteria"@en ;
   skos:altLabel "Eubacteria" ;
   skos:broader bioe:prokaryote ;
-  skos:definition "a large domain of prokaryotic microorganisms. Bacterial cells do not contain a nucleus and rarely harbour membrane-bound organelles.  The bacterial cell is surrounded by a cell membrane, which is made primarily of phospholipids. This membrane encloses the contents of the cell and acts as a barrier to hold nutrients, proteins and other essential components of the cytoplasm within the cell.  Bacterial cell walls are composed of peptidoglycan, a complex of protein and sugars, while archaeal cell walls are composed of polysaccharides (sugars). (https://en.wikipedia.org/wiki/Bacteria)"@en ;
+  skos:definition "a large domain of prokaryotic microorganisms. Bacterial cells do not contain a nucleus and rarely harbour membrane-bound organelles.  The bacterial cell is surrounded by a cell membrane, which is made primarily of phospholipids. This membrane encloses the contents of the cell and acts as a barrier to hold nutrients, proteins and other essential components of the cytoplasm within the cell.  Bacterial cell walls are composed of peptidoglycan, a complex of protein and sugars, while archaeal cell walls are composed of polysaccharides (sugars)."@en ;
+  dct:source "https://en.wikipedia.org/wiki/Bacteria";
   skos:prefLabel "Bacteria"@en ;
 .
 bioe:biologicentityvocabulary
@@ -142,49 +158,51 @@ bioe:biologicentityvocabulary
   skos:prefLabel "iSamples Biological Entity Extension Vocabulary"@en ;
 .
 bioe:bird
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Bird"@en ;
   skos:broader bioe:Vertebrate ;
   skos:definition "Vertebrates that have feathers, lightweight, hollow bones, a beak, an efficient respiratory system, and are warm-blooded. (ChatGPT) {@en} " ;
   skos:prefLabel "Bird"@en ;
 .
 bioe:bryophyte
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Bryophyte"@en ;
   skos:broader bioe:Plantae ;
   skos:definition "Non-vascular plants that do not have specialized tissues for transporting water and nutrients;  includes mosses, Marchantiophyta (liverworts), and Anthocerotophyta (hornworts). (ChatGPT)" ;
   skos:prefLabel "Bryophyte"@en ;
 .
 bioe:crustacea
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Crustaceans"@en ;
   skos:broader bioe:arthropod ;
-  skos:definition "arthropod taxon which includes such animals as decapods, seed shrimp, branchiopods, fish lice, krill, remipedes, isopods, barnacles, copepods, amphipods and mantis shrimp.  crustaceans have an exoskeleton, which they moult to grow. They are distinguished from other groups of arthropods, such as insects, myriapods and chelicerates, by the possession of biramous (two-parted) limbs, and by their larval forms, such as the nauplius stage of branchiopods and copepods. (https://en.wikipedia.org/wiki/Crustacean)"@en ;
+  skos:definition "arthropod taxon which includes such animals as decapods, seed shrimp, branchiopods, fish lice, krill, remipedes, isopods, barnacles, copepods, amphipods and mantis shrimp.  crustaceans have an exoskeleton, which they moult to grow. They are distinguished from other groups of arthropods, such as insects, myriapods and chelicerates, by the possession of biramous (two-parted) limbs, and by their larval forms, such as the nauplius stage of branchiopods and copepods."@en ;
+  dct:source "https://en.wikipedia.org/wiki/Crustacean";
   skos:prefLabel "Crustaceans"@en ;
 .
 bioe:eukaryote
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "eukaryote"@en ;
   skos:broader sf:biologicalentity ;
-  skos:definition "organism whose cells have a nucleus. Includes all animals, plants, fungi, and many unicellular organisms (https://en.wikipedia.org/wiki/Eukaryote)"@en ;
+  skos:definition "organism whose cells have a nucleus. Includes all animals, plants, fungi, and many unicellular organisms"@en ;
+  dct:source "https://en.wikipedia.org/wiki/Eukaryote";
   skos:prefLabel "Eukaryote"@en ;
 .
 bioe:eukaryoticmicroorganisms
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Eukaryotic microorganisms"@en ;
   skos:broader bioe:eukaryote ;
   skos:definition "Eukaryote single-cell organisms that does not fit in one of the other classes." ;
   skos:prefLabel "Eukaryotic microorganisms"@en ;
 .
 bioe:fish
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Fish"@en ;
   skos:broader bioe:Vertebrate ;
   skos:definition "Vertebrates that have gills, scales, fins, are cold-blooded, and commonly have a swim bladder; includes jawless fish, cartilaginous fish and bony fish. (ChatGPT)"@en ;
   skos:prefLabel "Fish"@en ;
 .
 bioe:hexapoda
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Insect"@en ;
   skos:altLabel "Hexapoda"@en ;
   skos:broader bioe:arthropod ;
@@ -192,37 +210,39 @@ bioe:hexapoda
   skos:prefLabel "Insect"@en ;
 .
 bioe:lichen
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Lichen"@en ;
   skos:broader sf:biologicalentity ;
   skos:definition "A composite organism that arises from algae or cyanobacteria living among filaments of multiple fungi species in a mutualistic relationship. (https://en.wikipedia.org/wiki/Lichen). Lichens are not classified under a specific kingdom as they are a symbiotic association between a fungus and either an alga or a cyanobacterium. The fungal partner belongs to the kingdom Fungi, while the algal or cyanobacterial partner belongs to either the kingdom Plantae or the kingdom Bacteria, respectively. (ChatGPT)"@en ;
   skos:prefLabel "Lichen"@en ;
 .
 bioe:macrofungi
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Macrofungi"@en ;
   skos:broader bioe:Fungi ;
-  skos:definition "Macrofungi refers to all fungi that produce visible fruiting bodies. These fungi are evolutionarily and ecologically very divergent. Evolutionarily, they belong to two main phyla, Ascomycota and Basidiomycota, and many of them have relatives that cannot form visible fruiting bodies.(https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6106070/)"@en ;
+  skos:definition "Macrofungi refers to all fungi that produce visible fruiting bodies. These fungi are evolutionarily and ecologically very divergent. Evolutionarily, they belong to two main phyla, Ascomycota and Basidiomycota, and many of them have relatives that cannot form visible fruiting bodies."@en ;
+  dct:source "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6106070/";
   skos:prefLabel "Macrofungi"@en ;
 .
 bioe:mammal
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Mammal"@en ;
   skos:broader bioe:Vertebrate ;
   skos:definition "vertebrates that have mammary glands, hair or fur, three middle ear bones, specialized teeth, and are warm-blooded. (ChatGPT)"@en ;
   skos:prefLabel "Mammal"@en ;
 .
 bioe:microfungi
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Microfungi"@en ;
   skos:altLabel "micromycetes"@en ;
   skos:broader bioe:Fungi ;
-  skos:definition "Microfungi or micromycetes are fungi—eukaryotic organisms such as molds, mildews and rusts—which have microscopic spore-producing structures. They exhibit tube tip-growth and have cell walls composed of chitin, a polymer of N-acetylglucosamine. Microfungi are a paraphyletic group, distinguished from macrofungi only by the absence of a large, multicellular fruiting body. Include moulds, yeasts. (https://en.wikipedia.org/wiki/Microfungi)"@en ;
+  skos:definition "Microfungi or micromycetes are fungi—eukaryotic organisms such as molds, mildews and rusts—which have microscopic spore-producing structures. They exhibit tube tip-growth and have cell walls composed of chitin, a polymer of N-acetylglucosamine. Microfungi are a paraphyletic group, distinguished from macrofungi only by the absence of a large, multicellular fruiting body. Include moulds, yeasts. "@en ;
+  dct:source "https://en.wikipedia.org/wiki/Microfungi";
   skos:note "Single-celled fungi are called yeast."@en ;
   skos:prefLabel "Microfungi"@en ;
 .
 bioe:mollusca
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Mollusca"@en ;
   skos:altLabel "bivalves" ;
   skos:altLabel "cephalopods" ;
@@ -232,14 +252,14 @@ bioe:mollusca
   skos:prefLabel "Mollusca"@en ;
 .
 bioe:myriapod
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Myriapod"@en ;
   skos:broader bioe:arthropod ;
   skos:definition "Arthropods such as millipedes and centipedes. (https://en.wikipedia.org/wiki/Myriapoda). A group of arthropods that have long, segmented body with numerous pairs of legs, simple eyes, specialized mouthparts, and a primarily terrestrial habitat, which distinguishes them from other arthropod groups such as insects and crustaceans. (ChatGPT)"@en ;
   skos:prefLabel "Myriapod"@en ;
 .
 bioe:myxomycete
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Myxomycetes"@en ;
   skos:altLabel "Mycetozoa"@en ;
   skos:broader bioe:amoebozoa ;
@@ -247,104 +267,110 @@ bioe:myxomycete
   skos:prefLabel "Myxomycetes"@en ;
 .
 bioe:otherarthropod
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Other arthropod "@en ;
   skos:broader bioe:arthropod ;
   skos:definition "includes Chelicerata (horseshoe crabs, scorpions, and sea spiders), Trilobitomorpha ( extinct trilobites), and  Pentastomida (parasitic arthropods that infect the respiratory systems of reptiles and mammals). (ChatGPT)"@en ;
   skos:prefLabel "Other arthropod "@en ;
 .
 bioe:otherinvertebrate
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Other invertebrate "@en ;
   skos:broader bioe:Animalia ;
   skos:definition "Includes Cnidaria (jellyfish, coral, anemones), Echinodermata (starfish, sea urchins, sea cucumbers), Nematoda (roundworms), Platyhelminthes (flatworms), Annelida (segmented worms), Ctenophora (comb jellies), Brachiopoda (lamp shells), Bryozoa (moss animals), Chaetognatha (arrow worms), Hemichordata (acorn worms), Xenacoelomorpha (simple-bodied worms) (ChatGPT)"@en ;
   skos:prefLabel "Other invertebrate "@en ;
 .
 bioe:otherplant
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Other  plant"@en ;
   skos:broader bioe:Plantae ;
-  skos:definition """plants that do not fit in other plant sub class. Includes Lycopodiophyta (clubmosses) and
-Equisetophyta (horsetails)""" ;
+  skos:definition "plants that do not fit in other plant sub class. Includes Lycopodiophyta (clubmosses) and Equisetophyta (horsetails)" ;
   skos:prefLabel "Other plant"@en ;
 .
 bioe:othervirus
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Other Virus "@en ;
   skos:broader bioe:virus ;
   skos:definition "Virus that is not a member of order Caudovirales (e.g., bacteriophage T4, lambda phage). " ;
   skos:prefLabel "Other Virus  "@en ;
 .
 bioe:phage
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Phage"@en ;
   skos:altLabel "bacteriophage"@en ;
   skos:broader bioe:virus ;
-  skos:definition "A bacteriophage, also known informally as a phage, is a duplodnaviria virus that infects and replicates within bacteria and archaea. Bacteriophages are composed of proteins that encapsulate a DNA or RNA genome, and may have structures that are either simple or elaborate. Their genomes may encode as few as four genes (e.g. MS2) and as many as hundreds of genes. Phages replicate within the bacterium following the injection of their genome into its cytoplasm. (https://en.wikipedia.org/wiki/Bacteriophage).  Includes all virus in order Caudovirales (e.g., bacteriophage T4, lambda phage)."@en ;
+  skos:definition "A bacteriophage, also known informally as a phage, is a duplodnaviria virus that infects and replicates within bacteria and archaea. Bacteriophages are composed of proteins that encapsulate a DNA or RNA genome, and may have structures that are either simple or elaborate. Their genomes may encode as few as four genes (e.g. MS2) and as many as hundreds of genes. Phages replicate within the bacterium following the injection of their genome into its cytoplasm.  Includes all virus in order Caudovirales (e.g., bacteriophage T4, lambda phage)."@en ;
+  dct:source "https://en.wikipedia.org/wiki/Bacteriophage";
   skos:prefLabel "Phage"@en ;
 .
 bioe:plasmid
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Plasmid"@en ;
   skos:broader sf:biologicalentity ;
-  skos:definition "A plasmid is a small, extrachromosomal DNA molecule within a cell that is physically separated from chromosomal DNA and can replicate independently. While chromosomes are large and contain all the essential genetic information for living under normal conditions, plasmids are usually very small and contain only additional genes that may be useful in certain situations or conditions. (https://en.wikipedia.org/wiki/Plasmid)"@en ;
+  skos:definition "A plasmid is a small, extrachromosomal DNA molecule within a cell that is physically separated from chromosomal DNA and can replicate independently. While chromosomes are large and contain all the essential genetic information for living under normal conditions, plasmids are usually very small and contain only additional genes that may be useful in certain situations or conditions."@en ;
+  dct:source "https://en.wikipedia.org/wiki/Plasmid";
   skos:prefLabel "Plasmid"@en ;
 .
 bioe:porifera
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Porifera"@en ;
   skos:altLabel "sponges" ;
   skos:broader bioe:Animalia ;
-  skos:definition "multicellular animals that have bodies full of pores and channels allowing water to circulate through them, consisting of jelly-like mesohyl sandwiched between two thin layers of cells. (https://en.wikipedia.org/wiki/Sponge)"@en ;
+  skos:definition "multicellular animals that have bodies full of pores and channels allowing water to circulate through them, consisting of jelly-like mesohyl sandwiched between two thin layers of cells."@en ;
   skos:prefLabel "Porifera"@en ;
+  dct:source "https://en.wikipedia.org/wiki/Sponge";
 .
 bioe:prokaryote
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Prokaryote"@en ;
   skos:altLabel "Monera"@en ;
   skos:broader sf:biologicalentity ;
-  skos:definition "single-celled organisms that lack a nucleus and other membrane-bound organelles. Unlike cells of animals and other eukaryotes, bacterial cells do not contain a nucleus and rarely harbour membrane-bound organelles. Molecular systematics showed prokaryotic life to consist of two separate domains, originally called Eubacteria and Archaebacteria, but now called Bacteria and Archaea that evolved independently from an ancient common ancestor. Almost all prokaryotes have a cell wall, a protective structure that allows them to survive in extreme conditions, which is located outside of their plasma membrane. Archaea and bacteria cannot reproduce sexually."@en ;
+  skos:definition "single-celled organisms that lack a nucleus and other membrane-bound organelles. Unlike cells of animals and other eukaryotes, bacterial cells do not contain a nucleus and rarely harbour membrane-bound organelles. Molecular systematics showed prokaryotic life to consist of two separate domains, originally called Eubacteria and Archaebacteria, but now called Bacteria and Archaea, that evolved independently from an ancient common ancestor. Almost all prokaryotes have a cell wall, a protective structure that allows them to survive in extreme conditions, which is located outside of their plasma membrane. Archaea and bacteria cannot reproduce sexually."@en ;
   skos:prefLabel "Prokaryote"@en ;
 .
 bioe:protozoa
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Protozoa"@en ;
   skos:broader bioe:Protista ;
-  skos:definition "A single-celled eukaryote, either free-living or parasitic, that feed on organic matter such as other microorganisms or organic tissues and debris. Historically, protozoans were regarded as 'one-celled animals', because they often possess animal-like behaviours, such as motility and predation, and lack a cell wall, as found in plants and many algae. (https://en.wikipedia.org/wiki/Protozoa)" ;
+  skos:definition "A single-celled eukaryote, either free-living or parasitic, that feed on organic matter such as other microorganisms or organic tissues and debris. Historically, protozoans were regarded as 'one-celled animals', because they often possess animal-like behaviours, such as motility and predation, and lack a cell wall, as found in plants and many algae." ;
+  dct:source "https://en.wikipedia.org/wiki/Protozoa";
   skos:prefLabel "Protozoa"@en ;
 .
 bioe:pteridophyte
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Pteridophyte"@en ;
   skos:broader bioe:Plantae ;
   skos:definition "a vascular plant (with xylem and phloem) that disperses spores; they produce neither flowers nor seeds, Includes  Ferns, horsetails (often treated as ferns), and lycophytes (clubmosses, spikemosses, and quillworts) " ;
   skos:prefLabel "Pteridophyte"@en ;
 .
 bioe:reptile
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Reptile"@en ;
   skos:broader bioe:Vertebrate ;
   skos:definition "Vertebrates that have scaly skin and claws, amniotic eggs, are cold-blooded, and are ectothermic (ChatGPT)"@en ;
   skos:prefLabel "Reptile"@en ;
 .
 bioe:spermatophyte
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Seed plant"@en ;
   skos:altLabel "spermatophyte"@en ;
   skos:broader bioe:Plantae ;
-  skos:definition "Plant that produces seeds, hence the alternative name seed plant. Spermatophytes are a subset of the embryophytes or land plants. They include most familiar types of plants, including all flowers and most trees, but exclude some other types of plants such as ferns, mosses, algae. (https://en.wikipedia.org/wiki/Spermatophyte). Includes Gymnosperms (naked-seed plants) and Angiosperms (flowering plants). " ;
+  skos:definition "Plant that produces seeds, hence the alternative name seed plant. Spermatophytes are a subset of the embryophytes or land plants. They include most familiar types of plants, including all flowers and most trees, but exclude some other types of plants such as ferns, mosses, algae. Includes Gymnosperms (naked-seed plants) and Angiosperms (flowering plants). " ;
+  dct:source "https://en.wikipedia.org/wiki/Spermatophyte";
   skos:prefLabel "Seed plant"@en ;
 .
 bioe:virus
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Virus"@en ;
   skos:broader sf:biologicalentity ;
-  skos:definition "A virus is a submicroscopic infectious agent that replicates only inside the living cells of an organism. Realms are Adnaviria, Duplodnaviria, Monodnaviria, Riboviria, Ribozyviria, Varidnaviria (https://en.wikipedia.org/wiki/Virus). Viruses are not cells at all, so they are neither prokaryotes nor eukaryotes. (https://bio.libretexts.org/Bookshelves/Introductory_and_General_Biology/Book)"@en ;
+  skos:definition "A virus is a submicroscopic infectious agent that replicates only inside the living cells of an organism. Realms are Adnaviria, Duplodnaviria, Monodnaviria, Riboviria, Ribozyviria, Varidnaviria. Viruses are not cells at all, so they are neither prokaryotes nor eukaryotes."@en ;
+  dct:source "https://bio.libretexts.org/Bookshelves/Introductory_and_General_Biology/Book";
+  dct:source "https://en.wikipedia.org/wiki/Virus"; 
   skos:description "animal and plant viruses"@en ;
   skos:prefLabel "Virus"@en ;
 .
 sf:biologicalentity
-  rdf:type skos:Concept ;
+  rdf:type skos:Concept ;   skos:inScheme bioe:biologicentityvocabulary  ;  
   rdfs:label "Biological entity"@en ;
   skos:definition "Sampled feature is an organism. Use for samples that represent some species of organism as the proximate sampled feature for which the focus is not the environment that the organism inhabits."@en ;
   skos:note "Based on DiSSCo listing in table 2 of https://docs.google.com/document/d/19OPyOm9VF2qfI3M6RmJPvRfo8JlZ3tt0II05aGCyBHQ/, draft DiSSCo specimen & collection classification (2023-03-27)"@en ;

--- a/src/extensions/mineralGroup.ttl
+++ b/src/extensions/mineralGroup.ttl
@@ -9,10 +9,17 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+<AWDID:2004562>
+  rdf:type schema:Grant ;
+  schema:funder <https://ror.org/04nh1dc89> ;
+  schema:name "Collaborative Research: Frameworks: Internet of Samples: Toward an Interdisciplinary Cyberinfrastructure for Material Samples" ;
+  schema:url "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" ;
+.
 dct:created
   rdf:type owl:AnnotationProperty ;
 .
@@ -28,6 +35,9 @@ dct:modified
   rdfs:comment "orchid-id: https://orcid.org/0000-0001-6041-5302" ;
   rdfs:label "Dr. Stephen M. Richard" ;
 .
+mat:mineral
+  skos:topConceptOf ming:mineralgroupvocabulary ;
+.
 ming:boratemineral
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;
@@ -35,7 +45,7 @@ ming:boratemineral
   rdfs:label "Mineral-Borate"@en ;
   skos:altLabel "Nickel-Strunz class 06"@en ;
   skos:broader mat:mineral ;
-  skos:definition "Minerals which contain a borate anion group."@en ;
+  skos:definition "Minerals that contain a borate anion group."@en ;
   skos:exactMatch <http://linked.data.gov.au/def/minerals/borates> ;
   skos:inScheme ming:mineralgroupvocabulary ;
   skos:prefLabel "Mineral-Borate"@en ;
@@ -81,6 +91,7 @@ ming:mineralgroupvocabulary
   skos:definition "Vocabulary to extend the mineral material type category with the top level mineral group categories. Uses the Nickel–Strunz mineral classes, which divide minerals into ten classes according to chemical composition and crystal structure. Nickel-Strunz group 10 is not included because that material would be mat:organiccompounds. Version 10 of the classification is modified from v 9 (Strunz and Nickel,2002) by Jim Ferraiolo and others, and now extended and maintained by mindat.org. Some scope notes from linked.data.gov.au. "@en ;
   skos:hasTopConcept mat:mineral ;
   skos:prefLabel "iSamples Mineral Group Vocabulary "@en ;
+  schema:funding <AWDID:2004562> ;
 .
 ming:nativeelementmineral
   rdf:type owl:NamedIndividual ;

--- a/src/extensions/rockSedimentExtension.ttl
+++ b/src/extensions/rockSedimentExtension.ttl
@@ -15,6 +15,12 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+<AWDID:2004562>
+  rdf:type schema:Grant ;
+  schema:funder <https://ror.org/04nh1dc89> ;
+  schema:name "Collaborative Research: Frameworks: Internet of Samples: Toward an Interdisciplinary Cyberinfrastructure for Material Samples" ;
+  schema:url "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" ;
+.
 gsoc:stephen_richard
   rdf:type owl:NamedIndividual ;
   rdf:type schema:Person ;
@@ -23,6 +29,12 @@ gsoc:stephen_richard
   schema:identifier <https://orcid.org/0000-0001-6041-5302> ;
   schema:name "Dr. Stephen M. Richard" ;
 .
+mat:rock
+  skos:topConceptOf rksd:rocksedimentvocabulary ;
+.
+mat:sediment
+  skos:topConceptOf rksd:rocksedimentvocabulary ;
+.
 rksd:Acidic_Igneous_Rock
   rdf:type skos:Concept ;
   dct:source "after LeMaitre et al. 2002"@en ;
@@ -30,6 +42,7 @@ rksd:Acidic_Igneous_Rock
   rdfs:label "acidic igneous rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Acidic_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Alkali_Feldspar_Granite
   rdf:type skos:Concept ;
@@ -38,6 +51,7 @@ rksd:Alkali_Feldspar_Granite
   rdfs:label "alkali feldspar granite"@en ;
   skos:broader rksd:Granitoid ;
   skos:closeMatch gsrm:Alkali_Feldspar_Granite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Andesite
   rdf:type skos:Concept ;
@@ -48,6 +62,7 @@ rksd:Andesite
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:broader rksd:Intermediate_Composition_Igneous_Rock ;
   skos:closeMatch gsrm:Andesite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Anorthositic_Rock
   rdf:type skos:Concept ;
@@ -57,6 +72,7 @@ rksd:Anorthositic_Rock
   rdfs:label "anorthositic rock"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Anorthositic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Aphanite
   rdf:type skos:Concept ;
@@ -65,6 +81,7 @@ rksd:Aphanite
   rdfs:label "aphanite"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Aphanite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Aplite
   rdf:type skos:Concept ;
@@ -73,6 +90,7 @@ rksd:Aplite
   rdfs:label "aplite"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Aplite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Basalt
   rdf:type skos:Concept ;
@@ -82,6 +100,7 @@ rksd:Basalt
   skos:broader rksd:Basic_Igneous_Rock ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:Basalt ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Basic_Igneous_Rock
   rdf:type skos:Concept ;
@@ -90,6 +109,7 @@ rksd:Basic_Igneous_Rock
   rdfs:label "basic igneous rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Basic_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Biogenic_Sediment
   rdf:type skos:Concept ;
@@ -99,6 +119,7 @@ rksd:Biogenic_Sediment
   rdfs:label "biogenic sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Biogenic_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Breccia
   rdf:type skos:Concept ;
@@ -107,6 +128,7 @@ rksd:Breccia
   rdfs:label "breccia"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Breccia ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Carbonate_Sediment
   rdf:type skos:Concept ;
@@ -115,6 +137,7 @@ rksd:Carbonate_Sediment
   rdfs:label "carbonate sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Carbonate_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Carbonate_Sedimentary_Rock
   rdf:type skos:Concept ;
@@ -124,6 +147,7 @@ rksd:Carbonate_Sedimentary_Rock
   rdfs:label "carbonate sedimentary rock"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Carbonate_Sedimentary_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Cataclasite_Series
   rdf:type skos:Concept ;
@@ -132,6 +156,7 @@ rksd:Cataclasite_Series
   rdfs:label "cataclasite series"@en ;
   skos:broader rksd:Fault_Related_Material ;
   skos:closeMatch gsrm:Cataclasite_Series ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Chemical_Sedimentary_Material
   rdf:type skos:Concept ;
@@ -140,6 +165,7 @@ rksd:Chemical_Sedimentary_Material
   rdfs:label "chemical sedimentary material"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Chemical_Sedimentary_Material ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Clastic_Sediment
   rdf:type skos:Concept ;
@@ -149,6 +175,7 @@ rksd:Clastic_Sediment
   rdfs:label "clastic sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Clastic_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Clastic_Sedimentary_Rock
   rdf:type skos:Concept ;
@@ -158,6 +185,7 @@ rksd:Clastic_Sedimentary_Rock
   rdfs:label "clastic sedimentary rock"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Clastic_Sedimentary_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Coal
   rdf:type skos:Concept ;
@@ -167,6 +195,7 @@ rksd:Coal
   rdfs:label "kohle"@de ;
   skos:broader rksd:Organic_Rich_Sedimentary_Rock ;
   skos:closeMatch gsrm:Coal ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Dacite
   rdf:type skos:Concept ;
@@ -176,6 +205,7 @@ rksd:Dacite
   skos:broader rksd:Acidic_Igneous_Rock ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:Dacite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Diamictite
   rdf:type skos:Concept ;
@@ -184,6 +214,7 @@ rksd:Diamictite
   rdfs:label "diamictite"@en ;
   skos:broader rksd:Clastic_Sedimentary_Rock ;
   skos:closeMatch gsrm:Diamictite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Diamicton
   rdf:type skos:Concept ;
@@ -193,6 +224,7 @@ rksd:Diamicton
   rdfs:label "diamicton"@en ;
   skos:broader rksd:Clastic_Sediment ;
   skos:closeMatch gsrm:Diamicton ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Dioritoid
   rdf:type skos:Concept ;
@@ -202,6 +234,7 @@ rksd:Dioritoid
   skos:broader rksd:Intermediate_Composition_Igneous_Rock ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Dioritoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Doleritic_Rock
   rdf:type skos:Concept ;
@@ -210,6 +243,7 @@ rksd:Doleritic_Rock
   rdfs:label "doleritic rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Doleritic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Exotic_Composition_Igneous_Rock
   rdf:type skos:Concept ;
@@ -218,6 +252,7 @@ rksd:Exotic_Composition_Igneous_Rock
   rdfs:label "exotic composition igneous rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Exotic_Composition_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Fault_Related_Material
   rdf:type skos:Concept ;
@@ -226,6 +261,7 @@ rksd:Fault_Related_Material
   rdfs:label "fault related material"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:fault_related_material ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Fine_Grained_Igneous_Rock
   rdf:type skos:Concept ;
@@ -236,6 +272,7 @@ rksd:Fine_Grained_Igneous_Rock
   skos:altLabel "volcanic rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Fine_Grained_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Foid_Dioritoid
   rdf:type skos:Concept ;
@@ -244,6 +281,7 @@ rksd:Foid_Dioritoid
   rdfs:label "foid dioritoid"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Foid_Dioritoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Foid_Gabbroid
   rdf:type skos:Concept ;
@@ -252,6 +290,7 @@ rksd:Foid_Gabbroid
   rdfs:label "foid gabbroid"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Foid_Gabbroid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Foid_Syenitoid
   rdf:type skos:Concept ;
@@ -260,6 +299,7 @@ rksd:Foid_Syenitoid
   rdfs:label "foid syenitoid"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Foid_Syenitoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Foiditoid
   rdf:type skos:Concept ;
@@ -270,6 +310,7 @@ rksd:Foiditoid
   skos:altLabel "foiditic rock"@en ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:Foiditoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Foidolite
   rdf:type skos:Concept ;
@@ -278,6 +319,7 @@ rksd:Foidolite
   rdfs:label "foidolite"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Foidolite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Fragmental_Igneous_Rock
   rdf:type skos:Concept ;
@@ -287,6 +329,7 @@ rksd:Fragmental_Igneous_Rock
   skos:broader mat:rock ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Fragmental_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Gabbroic_Rock
   rdf:type skos:Concept ;
@@ -296,6 +339,7 @@ rksd:Gabbroic_Rock
   skos:broader rksd:Basic_Igneous_Rock ;
   skos:broader rksd:Gabbroid ;
   skos:closeMatch gsrm:Gabbroic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Gabbroid
   rdf:type skos:Concept ;
@@ -304,6 +348,7 @@ rksd:Gabbroid
   rdfs:label "gabbroid"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Gabbroid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Generic_Conglomerate
   rdf:type skos:Concept ;
@@ -312,6 +357,7 @@ rksd:Generic_Conglomerate
   rdfs:label "generic conglomerate"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Generic_Conglomerate ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Generic_Mudstone
   rdf:type skos:Concept ;
@@ -321,6 +367,7 @@ rksd:Generic_Mudstone
   rdfs:label "generic mudstone"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Generic_Mudstone ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Generic_Sandstone
   rdf:type skos:Concept ;
@@ -329,6 +376,7 @@ rksd:Generic_Sandstone
   rdfs:label "generic sandstone"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Generic_Sandstone ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Glass_Rich_Igneous_Rock
   rdf:type skos:Concept ;
@@ -337,6 +385,7 @@ rksd:Glass_Rich_Igneous_Rock
   rdfs:label "glass rich igneous rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Glass_Rich_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Granite
   rdf:type skos:Concept ;
@@ -345,6 +394,7 @@ rksd:Granite
   rdfs:label "granite"@en ;
   skos:broader rksd:Granitoid ;
   skos:closeMatch gsrm:Granite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Granitoid
   rdf:type skos:Concept ;
@@ -355,6 +405,7 @@ rksd:Granitoid
   skos:broader rksd:Acidic_Igneous_Rock ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Granitoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Granodiorite
   rdf:type skos:Concept ;
@@ -363,6 +414,7 @@ rksd:Granodiorite
   rdfs:label "granodiorite"@en ;
   skos:broader rksd:Granitoid ;
   skos:closeMatch gsrm:Granodiorite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Gravel_Size_Sediment
   rdf:type skos:Concept ;
@@ -371,6 +423,7 @@ rksd:Gravel_Size_Sediment
   rdfs:label "gravel size sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Gravel_Size_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:High_Magnesium_Fine_Grained_Igneous_Rock
   rdf:type skos:Concept ;
@@ -379,6 +432,7 @@ rksd:High_Magnesium_Fine_Grained_Igneous_Rock
   rdfs:label "high magnesium fine grained igneous rock"@en ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:High_Magnesium_Fine_Grained_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Hornblendite
   rdf:type skos:Concept ;
@@ -388,6 +442,7 @@ rksd:Hornblendite
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:broader rksd:Ultramafic_Igneous_Rock ;
   skos:closeMatch gsrm:Hornblendite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Hybrid_Sediment
   rdf:type skos:Concept ;
@@ -396,6 +451,7 @@ rksd:Hybrid_Sediment
   rdfs:label "hybrid sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Hybrid_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Hybrid_Sedimentary_Rock
   rdf:type skos:Concept ;
@@ -404,6 +460,7 @@ rksd:Hybrid_Sedimentary_Rock
   rdfs:label "hybrid sedimentary rock"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Hybrid_Sedimentary_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Hypabyssal_Intrusive_Rock
   rdf:type skos:Concept ;
@@ -412,6 +469,7 @@ rksd:Hypabyssal_Intrusive_Rock
   rdfs:label "hypabyssal intrusive rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Hypabyssal_Intrusive_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Igneous_Rock
   rdf:type skos:Concept ;
@@ -420,6 +478,7 @@ rksd:Igneous_Rock
   rdfs:label "igneous rock"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Impact_Generated_Material
   rdf:type skos:Concept ;
@@ -428,6 +487,7 @@ rksd:Impact_Generated_Material
   rdfs:label "impact generated material"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:impact_generated_material ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Intermediate_Composition_Igneous_Rock
   rdf:type skos:Concept ;
@@ -436,6 +496,7 @@ rksd:Intermediate_Composition_Igneous_Rock
   rdfs:label "intermediate composition igneous rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Intermediate_Composition_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Iron_Rich_Sediment
   rdf:type skos:Concept ;
@@ -444,6 +505,7 @@ rksd:Iron_Rich_Sediment
   rdfs:label "iron rich sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Iron_Rich_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Iron_Rich_Sedimentary_Rock
   rdf:type skos:Concept ;
@@ -452,6 +514,7 @@ rksd:Iron_Rich_Sedimentary_Rock
   rdfs:label "iron rich sedimentary rock"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Iron_Rich_Sedimentary_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Massive_Sulphide
   rdf:type skos:Concept ;
@@ -461,6 +524,7 @@ rksd:Massive_Sulphide
   skos:altLabel "massive Sulfide"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Massive_Sulphide ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Metamorphic_Rock
   rdf:type skos:Concept ;
@@ -470,6 +534,7 @@ rksd:Metamorphic_Rock
   rdfs:label "metamorphic rock"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Metamorphic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Metasomatic_Rock
   rdf:type skos:Concept ;
@@ -479,6 +544,7 @@ rksd:Metasomatic_Rock
   rdfs:label "metasomatic rock"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Metasomatic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Monzogabbroic_Rock
   rdf:type skos:Concept ;
@@ -487,6 +553,7 @@ rksd:Monzogabbroic_Rock
   rdfs:label "monzogabbroic rock"@en ;
   skos:broader rksd:Gabbroid ;
   skos:closeMatch gsrm:Monzogabbroic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Mud_Size_Sediment
   rdf:type skos:Concept ;
@@ -495,6 +562,7 @@ rksd:Mud_Size_Sediment
   rdfs:label "mud size sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Mud_Size_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Mylonitic_Rock
   rdf:type skos:Concept ;
@@ -503,6 +571,7 @@ rksd:Mylonitic_Rock
   rdfs:label "mylonitic rock"@en ;
   skos:broader rksd:Fault_Related_Material ;
   skos:closeMatch gsrm:Mylonitic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Non_Clastic_Siliceous_Sediment
   rdf:type skos:Concept ;
@@ -511,6 +580,7 @@ rksd:Non_Clastic_Siliceous_Sediment
   rdfs:label "non clastic siliceous sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Non_Clastic_Siliceous_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Non_Clastic_Siliceous_Sedimentary_Rock
   rdf:type skos:Concept ;
@@ -520,6 +590,7 @@ rksd:Non_Clastic_Siliceous_Sedimentary_Rock
   rdfs:label "non clastic siliceous sedimentary rock"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Non_Clastic_Siliceous_Sedimentary_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Organic_Rich_Sedimentary_Rock
   rdf:type skos:Concept ;
@@ -529,6 +600,7 @@ rksd:Organic_Rich_Sedimentary_Rock
   rdfs:label "organic rich sedimentary rock"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Organic_Rich_Sedimentary_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Pegmatite
   rdf:type skos:Concept ;
@@ -537,6 +609,7 @@ rksd:Pegmatite
   rdfs:label "pegmatite"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Pegmatite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Peridotite
   rdf:type skos:Concept ;
@@ -546,6 +619,7 @@ rksd:Peridotite
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:broader rksd:Ultramafic_Igneous_Rock ;
   skos:closeMatch gsrm:Peridotite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Phaneritic_Igneous_Rock
   rdf:type skos:Concept ;
@@ -556,6 +630,7 @@ rksd:Phaneritic_Igneous_Rock
   skos:altLabel "plutonic rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Phaneritic_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Phonolitoid
   rdf:type skos:Concept ;
@@ -565,6 +640,7 @@ rksd:Phonolitoid
   skos:altLabel "phonolitic rock"@en ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:Phonolitoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Phosphate_Rich_Sediment
   rdf:type skos:Concept ;
@@ -573,6 +649,7 @@ rksd:Phosphate_Rich_Sediment
   rdfs:label "phosphate rich sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Phosphate_Rich_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Phosphorite
   rdf:type skos:Concept ;
@@ -581,6 +658,7 @@ rksd:Phosphorite
   rdfs:label "phosphorite"@en ;
   skos:broader rksd:Sedimentary_Rock ;
   skos:closeMatch gsrm:Phosphorite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Plutonic_Igneous_Rock
   rdf:type skos:Concept ;
@@ -589,6 +667,7 @@ rksd:Plutonic_Igneous_Rock
   rdfs:label "plutonic rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Plutonic_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Porphyry
   rdf:type skos:Concept ;
@@ -597,6 +676,7 @@ rksd:Porphyry
   rdfs:label "porphyry"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Porphyry ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Pyroclastic_Rock
   rdf:type skos:Concept ;
@@ -605,6 +685,7 @@ rksd:Pyroclastic_Rock
   rdfs:label "pyroclastic rock"@en ;
   skos:broader rksd:Fragmental_Igneous_Rock ;
   skos:closeMatch gsrm:Pyroclastic_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Pyroxenite
   rdf:type skos:Concept ;
@@ -614,6 +695,7 @@ rksd:Pyroxenite
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:broader rksd:Ultramafic_Igneous_Rock ;
   skos:closeMatch gsrm:Pyroxenite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Quartz_Rich_Igneous_Rock
   rdf:type skos:Concept ;
@@ -624,6 +706,7 @@ rksd:Quartz_Rich_Igneous_Rock
   skos:broader rksd:Acidic_Igneous_Rock ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Quartz_Rich_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Rhyolitoid
   rdf:type skos:Concept ;
@@ -635,6 +718,7 @@ rksd:Rhyolitoid
   skos:broader rksd:Acidic_Igneous_Rock ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:Rhyolitoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Sand_Size_Sediment
   rdf:type skos:Concept ;
@@ -643,6 +727,7 @@ rksd:Sand_Size_Sediment
   rdfs:label "sand size sediment"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Sand_Size_Sediment ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Sedimentary_Rock
   rdf:type skos:Concept ;
@@ -651,6 +736,7 @@ rksd:Sedimentary_Rock
   rdfs:label "sedimentary rock"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Sedimentary_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Syenitoid
   rdf:type skos:Concept ;
@@ -659,6 +745,7 @@ rksd:Syenitoid
   rdfs:label "syenitoid"@en ;
   skos:broader rksd:Phaneritic_Igneous_Rock ;
   skos:closeMatch gsrm:Syenitoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Tephra
   rdf:type skos:Concept ;
@@ -667,6 +754,7 @@ rksd:Tephra
   rdfs:label "tephra"@en ;
   skos:broader mat:sediment ;
   skos:closeMatch gsrm:Tephra ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Tephritoid
   rdf:type skos:Concept ;
@@ -676,6 +764,7 @@ rksd:Tephritoid
   skos:altLabel "tephritic rock"@en ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:Tephritoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Tonalite
   rdf:type skos:Concept ;
@@ -684,6 +773,7 @@ rksd:Tonalite
   rdfs:label "tonalite"@en ;
   skos:broader rksd:Granitoid ;
   skos:closeMatch gsrm:Tonalite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Trachytoid
   rdf:type skos:Concept ;
@@ -692,6 +782,7 @@ rksd:Trachytoid
   rdfs:label "trachytoid"@en ;
   skos:broader rksd:Fine_Grained_Igneous_Rock ;
   skos:closeMatch gsrm:Trachytoid ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Tuffite
   rdf:type skos:Concept ;
@@ -702,6 +793,7 @@ rksd:Tuffite
   rdfs:label "tuffite"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:Tuffite ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Ultrabasic_Igneous_Rock
   rdf:type skos:Concept ;
@@ -710,6 +802,7 @@ rksd:Ultrabasic_Igneous_Rock
   rdfs:label "ultrabasic igneous rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Ultrabasic_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:Ultramafic_Igneous_Rock
   rdf:type skos:Concept ;
@@ -718,6 +811,7 @@ rksd:Ultramafic_Igneous_Rock
   rdfs:label "ultramafic igneous rock"@en ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Ultramafic_Igneous_Rock ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:breccia_gouge_series
   rdf:type skos:Concept ;
@@ -726,6 +820,7 @@ rksd:breccia_gouge_series
   rdfs:label "breccia gouge series"@en ;
   skos:broader rksd:Fault_Related_Material ;
   skos:closeMatch gsrm:breccia_gouge_series ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:residual_material
   rdf:type skos:Concept ;
@@ -734,17 +829,23 @@ rksd:residual_material
   rdfs:label "residual material"@en ;
   skos:broader mat:rock ;
   skos:closeMatch gsrm:residual_material ;
+  skos:inScheme rksd:rocksedimentvocabulary ;
 .
 rksd:rocksedimentvocabulary
   rdf:type owl:Ontology ;
+  rdf:type skos:ConceptScheme ;
+  rdf:type schema:CreativeWork ;
   dct:created "2022-08-27"^^xsd:date ;
   dct:creator gsoc:stephen_richard ;
   dct:license <https://creativecommons.org/licenses/by/4.0/legalcode> ;
+  dct:modified "2023-07-27"^^xsd:date ;
   dct:source "http://resource.geosciml.org/classifierScheme/cgi/2016.01/simplelithology" ;
   dct:source "https://w3id.org/gso/rockmaterial/ontology" ;
   rdfs:comment "Rock and sediment categories for iSamples materialType classification. Remove anthropogenic materials and classes for consolidated or non-consolidated material; remove leaf classes subjectively based on abundance of material type and number of subclasses. There are 83 'mat:rock' subclasses; these include some classes that are non-consolidated material (e.g. fault gouge) but these are not sediment and adding 'material' classes that are independent of consolidation seems like more overhead than needed. Note that a given material is likely to fit in more that one class; for example the sediment subclasses include compositional classes (e.g. carbonate, clastic) as well as grain size classes (gravel-size sediment). A calcareous ooze sample would be both 'mud-size sediment' and 'carbonate sediment'.   Change owl:class to skos:concept, and rdfs:subClassOf to skos:broader."@en ;
   rdfs:label "iSamples rock and sediment vocabulary extension"@en ;
   owl:imports <http://www.w3.org/2004/02/skos/core> ;
   skos:definition "Kinds of rock material."@en ;
+  skos:historyNote "2023-07-27 SMR add funding link, and rdf types for ConceptScheme and CreativeWork."@en ;
   skos:prefLabel "iSamples rock and sediment vocabulary extension"@en ;
+  schema:funding <AWDID:2004562> ;
 .

--- a/src/extensions/rockSedimentExtension.ttl
+++ b/src/extensions/rockSedimentExtension.ttl
@@ -326,7 +326,6 @@ rksd:Fragmental_Igneous_Rock
   dct:source "This vocabulary"@en ;
   rdfs:comment "Igneous rock in which greater than 75 percent of the rock consists of fragments produced as a result of igneous rock-forming process. Includes pyroclastic rocks, autobreccia associated with lava flows and intrusive breccias. Excludes deposits reworked by epiclastic processes (see Tuffite)"@en ;
   rdfs:label "fragmental igneous rock"@en ;
-  skos:broader mat:rock ;
   skos:broader rksd:Igneous_Rock ;
   skos:closeMatch gsrm:Fragmental_Igneous_Rock ;
   skos:inScheme rksd:rocksedimentvocabulary ;

--- a/src/extensions/specimenTypeExtension.ttl
+++ b/src/extensions/specimenTypeExtension.ttl
@@ -388,7 +388,7 @@ esmat:core
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "Cylinder of rock or sediment extracted from within the earth, and representing the entire sample extracted during a single borehole drilling event.  Typically using some rotary drilling technology. In many cases the core is extracted in segments that are 'core sections'. A core from a single borehole is rarely a continous unbroken object; commonly parts of the core will break up during drilling or extraction, leaving gaps or sections that are granular material. Cores are normally composed of consolidated ('solid') material, but in some cases loosely consolidated material might be recovered, and considered sediment or tephra. To be called 'core' the material must be sufficiently consolidated to maintain a cylindrical shape. A core hasPart (hasChild) 'Core section'"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core"@en ;
@@ -408,7 +408,7 @@ esmat:corehalfround
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core half round"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "Half-cylindrical peice of consolidated material produced by along-axis split of a core whole round along a selected diameter .    Has childOf relation to core section or core, core section, or Core peice from which is was split"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core half round"@en ;
@@ -418,7 +418,7 @@ esmat:corepeice
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core peice"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "A cylindrical peice of consolidated earth material extracted as a single solid object between breaks in recovery of core from a borehole. has parent core section"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core peice"@en ;
@@ -428,7 +428,7 @@ esmat:corequarterround
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core quarter round"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "a partial cylindrical peice of consolidated material created by along-axis split of a core half round. Has Parent core half round"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core quarter round"@en ;
@@ -438,7 +438,7 @@ esmat:coresection
   dcterm:source "https://www.geosamples.org/vocabularies" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core section"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "Segment of a core representing some interval along the well bore. Child of Core"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core section"@en ;
@@ -448,7 +448,7 @@ esmat:coresubpeice
   dcterm:source "https://www.geosamples.org/vocabularies" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core subpeice"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "A peice of consolidated material broken from a core peice. has Parent core peice or core section"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core subpeice"@en ;
@@ -499,8 +499,8 @@ esmat:fiblamella
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "FIB lamella"@en ;
+  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:solidmaterialspecimen ;
   skos:definition "very thin sheet of solid material milled from a larger sample using a focused ion beam. Used for TEM analysis."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "FIB lamella"@en ;
@@ -520,8 +520,8 @@ esmat:glassslidesmear
   dcterm:source "https://pubs.usgs.gov/of/2001/of01-041/htmldocs/methods/sslide.htm" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Glass slide smear"@en ;
+  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:othersolidobject ;
   skos:definition "sample from a cell culture spread into a thin layer on a glass slide for optical investigation"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Glass slide smear"@en ;
@@ -542,7 +542,7 @@ esmat:individualsolidcube
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Individual solid cube"@en ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "? is this an anlytical preparation, or a decorative object?"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Individual solid cube"@en ;
@@ -552,7 +552,7 @@ esmat:individualsolidcylinder
   dcterm:source "may be core, plug sample, drill a cylinder from a core" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Individual solid cylinder"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "A cylindrical peice of consolidated material not obtained by subsurface drilling.  Cores drilled for paleomagnetic analysis are a common example. Tree ring cores are another..."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Individual solid cylinder"@en ;
@@ -605,10 +605,9 @@ esmat:mineralspecimen
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Mineral specimen"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "a solid object consisting of one particular mineral, or several minerals intended to be representative of one or more of the mineral species."@en ;
   skos:inScheme esmat:sampletype ;
-  skos:note "a sample is a 'Rock hand sample' or 'Mineral specimen' is based on whether the original collection intention is to represent a mineral species, or a rock type.  If the sample could be considered representative of a rock type or some particular mineral constitutent in the rock, classify as both."@en ;
   skos:prefLabel "Mineral specimen"@en ;
 .
 esmat:mountedsection
@@ -616,8 +615,8 @@ esmat:mountedsection
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Mounted section"@en ;
+  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a thin slice of a rock that has been mounted on a glass slide for optical study"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Mounted section"@en ;
@@ -638,8 +637,8 @@ esmat:peel
   dcterm:source "https://strata.uga.edu/cincy/fauna/bryozoanStudy/acetatePeels.html" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Peel"@en ;
+  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:othersolidobject ;
   skos:definition "Acetate peels are made by polishing a planar surface on a sample, etching it with acid to give it some relief, and then chemically melting a piece of acetate onto that surface. The acetate is then pulled off for examination under a microscope. The acetate preserves a fingerprint of the internal structure of the sample surface. Used in paleontology to study complex fossils, e.g. bryozoan."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Peel"@en ;
@@ -677,11 +676,11 @@ esmat:preparedrockpowder
 .
 esmat:pressedpellet
   rdf:type skos:Concept ;
-  dcterm:source "this vocabulary" ;
+  dcterm:source "" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Pressed pellet"@en ;
+  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a sample prepared by grinding a parent sample to a fine powder, mixing it with a binder, and pressing the mixture into a die at a pressure of between 15 and 35 tons to produce a solid disc for subsequent analysis, typically by X-Ray fluorescence."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Pressed pellet"@en ;
@@ -691,7 +690,7 @@ esmat:rockhandsample
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Rock hand sample"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "individual peice of rock broken from an outcrop or larger peice of rock."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Rock hand sample"@en ;
@@ -731,10 +730,22 @@ esmat:slab
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Slab"@en ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "a relatively planar rock sample,cut from a large sample to produce a tabular peice of rock with the irregular outline of the original sample on the diameter where the cut was mate."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Slab"@en ;
+.
+esmat:solidmaterialsample
+  rdf:type skos:Concept ;
+  dcterm:source "this vocabulary" ;
+  rdfs:isDefinedBy esmat:sampletype ;
+  rdfs:label "Solid material sample"@en ;
+  skos:broader spec:physicalspecimen ;
+  skos:definition "a sample that is either a solid object or aggregation composed of solid, non-biologic material. This is a generic class to allow for poorly constrained sample descriptions, could be an aggregation or a solid object, but is known not to be fluid or biological."@en ;
+  skos:inScheme esmat:sampletype ;
+  skos:note "This class subsumes most Research products, all 'Other solid object', 'Fossil', 'Artifact', 'Aggregation', 'Anthropogenic aggregation'.  These are included using skos 'has narrower'."@en ;
+  skos:prefLabel "Solid material sample"@en ;
+  skos:topConceptOf esmat:sampletype ;
 .
 esmat:thicksection
   rdf:type skos:Concept ;
@@ -772,7 +783,7 @@ esmat:uchannelsample
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "U-channel sample"@en ;
-  skos:broader spec:solidmaterialspecimen ;
+  skos:broader spec:othersolidobject ;
   skos:definition "a rectangular prism of loosely consolidated sediment extracted from a core segment. has parent core piece or core segment"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "U-channel sample"@en ;
@@ -797,9 +808,14 @@ spec:bundlebiomeaggregation
 spec:fluidincontainer
   skos:topConceptOf esmat:sampletype ;
 .
+spec:fossil
+  skos:broader esmat:solidmaterialsample ;
+.
 spec:genericaggregation
+  skos:broader esmat:solidmaterialsample ;
   skos:topConceptOf esmat:sampletype ;
 .
 spec:othersolidobject
+  skos:broader esmat:solidmaterialsample ;
   skos:topConceptOf esmat:sampletype ;
 .

--- a/src/extensions/specimenTypeExtension.ttl
+++ b/src/extensions/specimenTypeExtension.ttl
@@ -703,7 +703,7 @@ esmat:sampletype
   dcterm:contributor <https://orcid.org/0000-0001-6041-5302> ;
   dcterm:created "2023-07-01"^^xsd:date ;
   dcterm:creator <https://orcid.org/0000-0001-6041-5302> ;
-  dcterm:modified "2023-07-07"^^xsd:date ;
+  dcterm:modified "2023-07-27"^^xsd:date ;
   dcterm:publisher "iSamples project" ;
   rdfs:label "Earth and Environmental Science specimen type extension"@en ;
   owl:imports dcterm: ;
@@ -713,11 +713,18 @@ esmat:sampletype
   skos:definition "This concept scheme contains skos concepts for categorizing kinds of Earth Material sample types, extending the iSamples Material Sample Type vocabulary. Defintions from SESAR, ODM2, wikipedia, ESS-DIVE, and other sources; sources are cited with each term."@en ;
   skos:hasTopConcept spec:physicalspecimen ;
   skos:historyNote "2023-07-07 SMR add solid material sample and broader relations from classes it subsumes."@en ;
-  skos:inScheme spec:specimentypevocabulary ;
+  skos:historyNote "2023-07-27 SMR modify base specimen type vocabulary, add 'Non biologic solid object' to replace 'solid material sample', change broader relations in this vocab to use that as parent class where appropriate. 'Solid material sample' is too closely linked to material type, created confusion. Intention is a specimen category for solid objects that are not biologic. Obviously there is some overlap with Research specimens."@en ;
   skos:prefLabel "Earth and Environmental Science specimen type extension"@en ;
-  schema:funding "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" ;
+  schema:funding <AWDID:2004562>;
   schema:provider "TBD" ;
 .
+
+<AWDID:2004562> rdf:type schema:Grant;
+  schema:funder <https://ror.org/04nh1dc89>;
+  schema:name "Collaborative Research: Frameworks: Internet of Samples: Toward an Interdisciplinary Cyberinfrastructure for Material Samples";
+  schema:url   "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" 
+  .
+  
 esmat:slab
   rdf:type skos:Concept ;
   dcterm:source "this vocabulary" ;
@@ -783,9 +790,7 @@ esmat:ultrathinsection
 spec:analyticalpreparation
   skos:topConceptOf esmat:sampletype ;
 .
-spec:artifact
-  skos:note "A sample is classified as an artifact if it is intended to represent the manufactured item.  For example, core, thin section, peel, glass slide smear are products of human manufacture, but are intended to represent materials or biological specimens."@en ;
-.
+
 spec:bundlebiomeaggregation
   skos:topConceptOf esmat:sampletype ;
 .

--- a/src/extensions/specimenTypeExtension.ttl
+++ b/src/extensions/specimenTypeExtension.ttl
@@ -388,7 +388,7 @@ esmat:core
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "Cylinder of rock or sediment extracted from within the earth, and representing the entire sample extracted during a single borehole drilling event.  Typically using some rotary drilling technology. In many cases the core is extracted in segments that are 'core sections'. A core from a single borehole is rarely a continous unbroken object; commonly parts of the core will break up during drilling or extraction, leaving gaps or sections that are granular material. Cores are normally composed of consolidated ('solid') material, but in some cases loosely consolidated material might be recovered, and considered sediment or tephra. To be called 'core' the material must be sufficiently consolidated to maintain a cylindrical shape. A core hasPart (hasChild) 'Core section'"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core"@en ;
@@ -408,7 +408,7 @@ esmat:corehalfround
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core half round"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "Half-cylindrical peice of consolidated material produced by along-axis split of a core whole round along a selected diameter .    Has childOf relation to core section or core, core section, or Core peice from which is was split"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core half round"@en ;
@@ -418,7 +418,7 @@ esmat:corepeice
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core peice"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "A cylindrical peice of consolidated earth material extracted as a single solid object between breaks in recovery of core from a borehole. has parent core section"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core peice"@en ;
@@ -428,7 +428,7 @@ esmat:corequarterround
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core quarter round"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a partial cylindrical peice of consolidated material created by along-axis split of a core half round. Has Parent core half round"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core quarter round"@en ;
@@ -438,7 +438,7 @@ esmat:coresection
   dcterm:source "https://www.geosamples.org/vocabularies" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core section"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "Segment of a core representing some interval along the well bore. Child of Core"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core section"@en ;
@@ -448,7 +448,7 @@ esmat:coresubpeice
   dcterm:source "https://www.geosamples.org/vocabularies" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core subpeice"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "A peice of consolidated material broken from a core peice. has Parent core peice or core section"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core subpeice"@en ;
@@ -499,8 +499,8 @@ esmat:fiblamella
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "FIB lamella"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "very thin sheet of solid material milled from a larger sample using a focused ion beam. Used for TEM analysis."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "FIB lamella"@en ;
@@ -520,8 +520,8 @@ esmat:glassslidesmear
   dcterm:source "https://pubs.usgs.gov/of/2001/of01-041/htmldocs/methods/sslide.htm" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Glass slide smear"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:othersolidobject ;
   skos:definition "sample from a cell culture spread into a thin layer on a glass slide for optical investigation"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Glass slide smear"@en ;
@@ -542,7 +542,7 @@ esmat:individualsolidcube
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Individual solid cube"@en ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "? is this an anlytical preparation, or a decorative object?"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Individual solid cube"@en ;
@@ -552,7 +552,7 @@ esmat:individualsolidcylinder
   dcterm:source "may be core, plug sample, drill a cylinder from a core" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Individual solid cylinder"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "A cylindrical peice of consolidated material not obtained by subsurface drilling.  Cores drilled for paleomagnetic analysis are a common example. Tree ring cores are another..."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Individual solid cylinder"@en ;
@@ -605,9 +605,10 @@ esmat:mineralspecimen
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Mineral specimen"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a solid object consisting of one particular mineral, or several minerals intended to be representative of one or more of the mineral species."@en ;
   skos:inScheme esmat:sampletype ;
+  skos:note "a sample is a 'Rock hand sample' or 'Mineral specimen' is based on whether the original collection intention is to represent a mineral species, or a rock type.  If the sample could be considered representative of a rock type or some particular mineral constitutent in the rock, classify as both."@en ;
   skos:prefLabel "Mineral specimen"@en ;
 .
 esmat:mountedsection
@@ -615,8 +616,8 @@ esmat:mountedsection
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Mounted section"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a thin slice of a rock that has been mounted on a glass slide for optical study"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Mounted section"@en ;
@@ -637,8 +638,8 @@ esmat:peel
   dcterm:source "https://strata.uga.edu/cincy/fauna/bryozoanStudy/acetatePeels.html" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Peel"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:othersolidobject ;
   skos:definition "Acetate peels are made by polishing a planar surface on a sample, etching it with acid to give it some relief, and then chemically melting a piece of acetate onto that surface. The acetate is then pulled off for examination under a microscope. The acetate preserves a fingerprint of the internal structure of the sample surface. Used in paleontology to study complex fossils, e.g. bryozoan."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Peel"@en ;
@@ -676,11 +677,11 @@ esmat:preparedrockpowder
 .
 esmat:pressedpellet
   rdf:type skos:Concept ;
-  dcterm:source "" ;
+  dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Pressed pellet"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a sample prepared by grinding a parent sample to a fine powder, mixing it with a binder, and pressing the mixture into a die at a pressure of between 15 and 35 tons to produce a solid disc for subsequent analysis, typically by X-Ray fluorescence."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Pressed pellet"@en ;
@@ -690,7 +691,7 @@ esmat:rockhandsample
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Rock hand sample"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "individual peice of rock broken from an outcrop or larger peice of rock."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Rock hand sample"@en ;
@@ -723,22 +724,10 @@ esmat:slab
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Slab"@en ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a relatively planar rock sample,cut from a large sample to produce a tabular peice of rock with the irregular outline of the original sample on the diameter where the cut was mate."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Slab"@en ;
-.
-esmat:solidmaterialsample
-  rdf:type skos:Concept ;
-  dcterm:source "this vocabulary" ;
-  rdfs:isDefinedBy esmat:sampletype ;
-  rdfs:label "Solid material sample"@en ;
-  skos:broader spec:physicalspecimen ;
-  skos:definition "a sample that is either a solid object or aggregation composed of solid, non-biologic material. This is a generic class to allow for poorly constrained sample descriptions, could be an aggregation or a solid object, but is known not to be fluid or biological."@en ;
-  skos:inScheme esmat:sampletype ;
-  skos:note "This class subsumes most Research products, all 'Other solid object', 'Fossil', 'Artifact', 'Aggregation', 'Anthropogenic aggregation'.  These are included using skos 'has narrower'."@en ;
-  skos:prefLabel "Solid material sample"@en ;
-  skos:topConceptOf esmat:sampletype ;
 .
 esmat:thicksection
   rdf:type skos:Concept ;
@@ -776,7 +765,7 @@ esmat:uchannelsample
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "U-channel sample"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a rectangular prism of loosely consolidated sediment extracted from a core segment. has parent core piece or core segment"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "U-channel sample"@en ;
@@ -794,11 +783,8 @@ esmat:ultrathinsection
 spec:analyticalpreparation
   skos:topConceptOf esmat:sampletype ;
 .
-spec:anthropogenicaggregation
-  skos:broader esmat:solidmaterialsample ;
-.
 spec:artifact
-  skos:broader esmat:solidmaterialsample ;
+  skos:note "A sample is classified as an artifact if it is intended to represent the manufactured item.  For example, core, thin section, peel, glass slide smear are products of human manufacture, but are intended to represent materials or biological specimens."@en ;
 .
 spec:bundlebiomeaggregation
   skos:topConceptOf esmat:sampletype ;
@@ -806,14 +792,9 @@ spec:bundlebiomeaggregation
 spec:fluidincontainer
   skos:topConceptOf esmat:sampletype ;
 .
-spec:fossil
-  skos:broader esmat:solidmaterialsample ;
-.
 spec:genericaggregation
-  skos:broader esmat:solidmaterialsample ;
   skos:topConceptOf esmat:sampletype ;
 .
 spec:othersolidobject
-  skos:broader esmat:solidmaterialsample ;
   skos:topConceptOf esmat:sampletype ;
 .

--- a/src/extensions/specimenTypeExtension.ttl
+++ b/src/extensions/specimenTypeExtension.ttl
@@ -388,7 +388,7 @@ esmat:core
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "Cylinder of rock or sediment extracted from within the earth, and representing the entire sample extracted during a single borehole drilling event.  Typically using some rotary drilling technology. In many cases the core is extracted in segments that are 'core sections'. A core from a single borehole is rarely a continous unbroken object; commonly parts of the core will break up during drilling or extraction, leaving gaps or sections that are granular material. Cores are normally composed of consolidated ('solid') material, but in some cases loosely consolidated material might be recovered, and considered sediment or tephra. To be called 'core' the material must be sufficiently consolidated to maintain a cylindrical shape. A core hasPart (hasChild) 'Core section'"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core"@en ;
@@ -408,7 +408,7 @@ esmat:corehalfround
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core half round"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "Half-cylindrical peice of consolidated material produced by along-axis split of a core whole round along a selected diameter .    Has childOf relation to core section or core, core section, or Core peice from which is was split"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core half round"@en ;
@@ -418,7 +418,7 @@ esmat:corepeice
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core peice"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "A cylindrical peice of consolidated earth material extracted as a single solid object between breaks in recovery of core from a borehole. has parent core section"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core peice"@en ;
@@ -428,7 +428,7 @@ esmat:corequarterround
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core quarter round"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a partial cylindrical peice of consolidated material created by along-axis split of a core half round. Has Parent core half round"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core quarter round"@en ;
@@ -438,7 +438,7 @@ esmat:coresection
   dcterm:source "https://www.geosamples.org/vocabularies" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core section"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "Segment of a core representing some interval along the well bore. Child of Core"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core section"@en ;
@@ -448,7 +448,7 @@ esmat:coresubpeice
   dcterm:source "https://www.geosamples.org/vocabularies" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Core subpeice"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "A peice of consolidated material broken from a core peice. has Parent core peice or core section"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Core subpeice"@en ;
@@ -499,8 +499,8 @@ esmat:fiblamella
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "FIB lamella"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "very thin sheet of solid material milled from a larger sample using a focused ion beam. Used for TEM analysis."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "FIB lamella"@en ;
@@ -520,8 +520,8 @@ esmat:glassslidesmear
   dcterm:source "https://pubs.usgs.gov/of/2001/of01-041/htmldocs/methods/sslide.htm" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Glass slide smear"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:othersolidobject ;
   skos:definition "sample from a cell culture spread into a thin layer on a glass slide for optical investigation"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Glass slide smear"@en ;
@@ -542,7 +542,7 @@ esmat:individualsolidcube
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Individual solid cube"@en ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "? is this an anlytical preparation, or a decorative object?"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Individual solid cube"@en ;
@@ -552,7 +552,7 @@ esmat:individualsolidcylinder
   dcterm:source "may be core, plug sample, drill a cylinder from a core" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Individual solid cylinder"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "A cylindrical peice of consolidated material not obtained by subsurface drilling.  Cores drilled for paleomagnetic analysis are a common example. Tree ring cores are another..."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Individual solid cylinder"@en ;
@@ -605,9 +605,10 @@ esmat:mineralspecimen
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Mineral specimen"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a solid object consisting of one particular mineral, or several minerals intended to be representative of one or more of the mineral species."@en ;
   skos:inScheme esmat:sampletype ;
+  skos:note "a sample is a 'Rock hand sample' or 'Mineral specimen' is based on whether the original collection intention is to represent a mineral species, or a rock type.  If the sample could be considered representative of a rock type or some particular mineral constitutent in the rock, classify as both."@en ;
   skos:prefLabel "Mineral specimen"@en ;
 .
 esmat:mountedsection
@@ -615,8 +616,8 @@ esmat:mountedsection
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Mounted section"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a thin slice of a rock that has been mounted on a glass slide for optical study"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Mounted section"@en ;
@@ -637,8 +638,8 @@ esmat:peel
   dcterm:source "https://strata.uga.edu/cincy/fauna/bryozoanStudy/acetatePeels.html" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Peel"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:othersolidobject ;
   skos:definition "Acetate peels are made by polishing a planar surface on a sample, etching it with acid to give it some relief, and then chemically melting a piece of acetate onto that surface. The acetate is then pulled off for examination under a microscope. The acetate preserves a fingerprint of the internal structure of the sample surface. Used in paleontology to study complex fossils, e.g. bryozoan."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Peel"@en ;
@@ -676,11 +677,11 @@ esmat:preparedrockpowder
 .
 esmat:pressedpellet
   rdf:type skos:Concept ;
-  dcterm:source "" ;
+  dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Pressed pellet"@en ;
-  skos:broader esmat:solidmaterialsample ;
   skos:broader spec:analyticalpreparation ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a sample prepared by grinding a parent sample to a fine powder, mixing it with a binder, and pressing the mixture into a die at a pressure of between 15 and 35 tons to produce a solid disc for subsequent analysis, typically by X-Ray fluorescence."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Pressed pellet"@en ;
@@ -690,7 +691,7 @@ esmat:rockhandsample
   dcterm:source "this vocabulary" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Rock hand sample"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "individual peice of rock broken from an outcrop or larger peice of rock."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Rock hand sample"@en ;
@@ -730,22 +731,10 @@ esmat:slab
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "Slab"@en ;
   skos:broader spec:analyticalpreparation ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a relatively planar rock sample,cut from a large sample to produce a tabular peice of rock with the irregular outline of the original sample on the diameter where the cut was mate."@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "Slab"@en ;
-.
-esmat:solidmaterialsample
-  rdf:type skos:Concept ;
-  dcterm:source "this vocabulary" ;
-  rdfs:isDefinedBy esmat:sampletype ;
-  rdfs:label "Solid material sample"@en ;
-  skos:broader spec:physicalspecimen ;
-  skos:definition "a sample that is either a solid object or aggregation composed of solid, non-biologic material. This is a generic class to allow for poorly constrained sample descriptions, could be an aggregation or a solid object, but is known not to be fluid or biological."@en ;
-  skos:inScheme esmat:sampletype ;
-  skos:note "This class subsumes most Research products, all 'Other solid object', 'Fossil', 'Artifact', 'Aggregation', 'Anthropogenic aggregation'.  These are included using skos 'has narrower'."@en ;
-  skos:prefLabel "Solid material sample"@en ;
-  skos:topConceptOf esmat:sampletype ;
 .
 esmat:thicksection
   rdf:type skos:Concept ;
@@ -783,7 +772,7 @@ esmat:uchannelsample
   dcterm:source "https://www.geosamples.org/vocabularies/sample-type-object" ;
   rdfs:isDefinedBy esmat:sampletype ;
   rdfs:label "U-channel sample"@en ;
-  skos:broader spec:othersolidobject ;
+  skos:broader spec:solidmaterialspecimen ;
   skos:definition "a rectangular prism of loosely consolidated sediment extracted from a core segment. has parent core piece or core segment"@en ;
   skos:inScheme esmat:sampletype ;
   skos:prefLabel "U-channel sample"@en ;
@@ -808,14 +797,9 @@ spec:bundlebiomeaggregation
 spec:fluidincontainer
   skos:topConceptOf esmat:sampletype ;
 .
-spec:fossil
-  skos:broader esmat:solidmaterialsample ;
-.
 spec:genericaggregation
-  skos:broader esmat:solidmaterialsample ;
   skos:topConceptOf esmat:sampletype ;
 .
 spec:othersolidobject
-  skos:broader esmat:solidmaterialsample ;
   skos:topConceptOf esmat:sampletype ;
 .

--- a/src/materialtype.ttl
+++ b/src/materialtype.ttl
@@ -7,10 +7,17 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+<AWDID:2004562>
+  rdf:type schema:Grant ;
+  schema:funder <https://ror.org/04nh1dc89> ;
+  schema:name "Collaborative Research: Frameworks: Internet of Samples: Toward an Interdisciplinary Cyberinfrastructure for Material Samples" ;
+  schema:url "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" ;
+.
 dct:created
   rdf:type owl:AnnotationProperty ;
 .
@@ -146,9 +153,11 @@ mat:materialsvocabulary
   rdfs:label "iSamples Materials Vocabulary"@en ;
   owl:imports <http://www.w3.org/2004/02/skos/core> ;
   skos:definition "High level vocabulary to specify the kind of material that constitutes a physical sample"@en ;
+  skos:hasTopConcept mat:material ;
   skos:historyNote "2022-01-05 SMR version 0.9, change base uri to https://w3id.org/isample/vocabulary/material/0.9/ for testing with ESIP COR and w3id uri resolution"@en ;
   skos:historyNote "2022-03-11 SMR change definitions from rdfs:comment to skos:definition. Minor fixes to some definitions.  Add skos matches to URIs from other vocabularies."@en ;
   skos:prefLabel "iSamples Materials Vocabulary "@en ;
+  schema:funding <AWDID:2004562> ;
 .
 mat:mineral
   rdf:type owl:NamedIndividual ;

--- a/src/materialtype.ttl
+++ b/src/materialtype.ttl
@@ -174,7 +174,7 @@ mat:mixedsoilsedimentrock
   rdf:type skos:Concept ;
   rdfs:label "Mixed soil sediment or rock"@en ;
   skos:broader mat:earthmaterial ;
-  skos:definition "Material is mixed aggregation of fragments of undifferentiated soil, sediment or  rock origin. e.g. cuttings from some boreholes (rock fragments and caved soil or sediment), sea floor dredge haul (mixed sediment and rock)"@en ;
+  skos:definition "Material is mixed aggregation of fragments of undifferentiated soil, sediment or rock origin. e.g. cuttings from some boreholes (rock fragments and caved soil or sediment), sea floor dredge haul (mixed sediment and rock)"@en ;
   skos:inScheme mat:materialsvocabulary ;
   skos:note "This class is for samples that are solid Earth materials but known not to be mineral or particulate samples."@en ;
   skos:prefLabel "Mixed soil sediment or rock"@en ;
@@ -241,6 +241,8 @@ mat:rockorsediment
   skos:broader mat:earthmaterial ;
   skos:definition "Material is rock or sediment.  E.g. for samples from subsurface cores that are not well described, from drill holes that likely penetrate sediment near the surface an might be sampling rock at greater depth."@en ;
   skos:inScheme mat:materialsvocabulary ;
+  skos:note "Use for sample like dredge hauls and ROV scoops that mix rock and sediment from a water body bottom."@en ;
+  skos:note "Use for samples described as rock>sedimentary AND sediment, where it is unclear whether the sample is a consolidated 'rock' object, or loose disaggregated material in a bag."@en ;
   skos:prefLabel "Rock or sediment"@en ;
   skos:scopeNote "distinct from 'Mixed soil, sediment or rock' that represents samples known to have components of all these materials."@en ;
 .

--- a/src/sampledfeature.ttl
+++ b/src/sampledfeature.ttl
@@ -10,6 +10,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <https://schema.org/> .
 
 <http://purl.bioontology.org/ontology/MESH/D005118>
   rdf:type owl:NamedIndividual ;
@@ -226,8 +227,16 @@ sf:sampledfeaturevocabulary
   skos:historyNote "Remove Marine biome, Subaerial terrestrial environment, Subaqueous terrestrial environment per github issue https://github.com/isamplesorg/metadata/issues/41. Make Experiment setting and Laboratory or curatorial environemtn  subclasses of Active human occupation site."@en ;
   skos:historyNote "2022-09-07 SMR update some of the skos mappings to other vocabularies; remove references to other vocabularies as NamedIndividual. Remove rocksample class, it was not linked in hierarchy and inconsistent with design."@en ;
   skos:historyNote "2022-09-30 add biological entity as sampled feature, per issue https://github.com/isamplesorg/metadata/issues/107. This update was lost at some point and added back in 2022-12-09."@en ;
+    schema:funding <AWDID:2004562>;
   skos:prefLabel "Sampled Feature Type vocabulary"@en ;
 .
+
+<AWDID:2004562> rdf:type schema:Grant;
+  schema:funder <https://ror.org/04nh1dc89>;
+  schema:name "Collaborative Research: Frameworks: Internet of Samples: Toward an Interdisciplinary Cyberinfrastructure for Material Samples";
+  schema:url   "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" 
+  .
+
 sf:subaerialsurfaceenvironment
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;

--- a/src/specimentype.ttl
+++ b/src/specimentype.ttl
@@ -65,7 +65,7 @@ spec:artifact
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;
   rdfs:label "Artifact"@en ;
-  skos:broader spec:physicalspecimen ;
+  skos:broader spec:nonbiologicsolidobject ;
   skos:closeMatch <https://en.wikipedia.org/wiki/Artifact_(archaeology)> ;
   skos:definition "An object made (manufactured, shaped, modified) by a human being, or precursor hominid. Include a set of pieces belonging originally to a single object and treated as a single specimen."@en ;
   skos:inScheme spec:specimentypevocabulary ;
@@ -123,8 +123,8 @@ spec:fossil
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;
   rdfs:label "Fossil"@en ;
-  skos:broader spec:physicalspecimen ;
-  skos:definition "Specimen is the remains of one or more organisms preserved in rock; includes whole body, body parts (usually bone or shell), and trace fossils. An organism or organism part becomes a fossil when it has undergone some fossilization process that generally entails physical and chemical changes akin to diagenesis in a sedimentary rock. Trace fossils are manifestations of biologic activity preserved in a rock body (typically sedimentary), without included preserved body parts."@en ;
+  skos:broader spec:nonbiologicsolidobject ;
+  skos:definition "Specimen is the remains of one or more organisms preserved in rock; includes whole body, body parts (usually bone or shell), and trace fossils. An organism or organism part becomes a fossil when it has undergone some fossilization process that generally entails physical and chemical changes akin to diagenesis in a sedimentary rock. Includes trace fossils, which are manifestations of biologic activity preserved in a rock body (typically sedimentary), without included preserved body parts."@en ;
   skos:exactMatch <http://sweet.jpl.nasa.gov/2.3/matrRock.owl#Fossil> ;
   skos:exactMatch <https://en.wikipedia.org/wiki/Fossil> ;
   skos:inScheme spec:specimentypevocabulary ;
@@ -139,6 +139,13 @@ spec:genericaggregation
   skos:definition "An aggregate specimen that is not biogenic or composed of anthropogenic material fragments.  Examples: loose soil or sediment (e.g. in a bag), rock chips, particulate filtrate or precipitate; rock powders."@en ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Aggregation"@en ;
+.
+spec:nonbiologicsolidobject
+  rdf:type skos:Concept ;
+  rdfs:label "Non biologic solid object"@en ;
+  skos:broader spec:physicalspecimen ;
+  skos:definition "Individual solid object, not formed directly by or part of a living organism"@en ;
+  skos:prefLabel "Non biologic solid object"@en ;
 .
 spec:organismpart
   rdf:type owl:NamedIndividual ;
@@ -166,8 +173,8 @@ spec:othersolidobject
   rdfs:label "Other solid object"@en ;
   skos:broadMatch <http://purl.obolibrary.org/obo/BFO_0000030> ;
   skos:broadMatch <http://semanticscience.org/resource/SIO_000776> ;
-  skos:broader spec:physicalspecimen ;
-  skos:definition "Single piece of material not one of the other types, e.g. rock specimen, mineral specimen, core. Ice and permafrost are considered solid materials."@en ;
+  skos:broader spec:nonbiologicsolidobject ;
+  skos:definition "Single piece of material not one of the other types." ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Other solid object"@en ;
   skos:relatedMatch <http://purl.obolibrary.org/obo/BFO_0000030> ;
@@ -198,6 +205,14 @@ spec:slurrybiomeaggregation
   skos:definition "a material that consists of mixed organic and inorganic material, including whole organisms and organism fragments."@en ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Slurry biome aggregation"@en ;
+.
+spec:solidmaterialspecimen
+  rdf:type skos:Concept ;
+  rdfs:label "Solid material specimen"@en ;
+  skos:broader spec:nonbiologicsolidobject ;
+  skos:definition "Individual solid object, not formed directly by or part of a living organism, that is representative of some material."@en ;
+  skos:note "e.g. a rock or mineral specimen, a specimen of some manufactured material, a meteorite. Ice and permafrost are considered solid materials. {@en}"@en ;
+  skos:prefLabel "Solid material specimen"@en ;
 .
 spec:specimentypevocabulary
   rdf:type owl:NamedIndividual ;

--- a/src/specimentype.ttl
+++ b/src/specimentype.ttl
@@ -211,7 +211,8 @@ spec:solidmaterialspecimen
   rdfs:label "Solid material specimen"@en ;
   skos:broader spec:nonbiologicsolidobject ;
   skos:definition "Individual solid object, not formed directly by or part of a living organism, that is representative of some material."@en ;
-  skos:note "e.g. a rock or mineral specimen, a specimen of some manufactured material, a meteorite. Ice and permafrost are considered solid materials. {@en}"@en ;
+  skos:note "Many sediment cores consist of non-consolidated or weakly consolidated material, but are considered solid objects if the core is preserved intact to observe the sedimentary structures and particle relationships within the sediment. If this material were 'disaggregated' into a mass of granular material to put in a bag, it would become an aggregate (spec:genericaggregation)."@en ;
+  skos:note "e.g. a rock or mineral specimen, a specimen of some manufactured material, a meteorite. Ice and permafrost are considered solid materials."@en ;
   skos:prefLabel "Solid material specimen"@en ;
 .
 spec:specimentypevocabulary

--- a/src/specimentype.ttl
+++ b/src/specimentype.ttl
@@ -58,7 +58,7 @@ spec:artifact
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;
   rdfs:label "Artifact"@en ;
-  skos:broader spec:physicalspecimen ;
+  skos:broader spec:nonbiologicsolidobject ;
   skos:closeMatch <https://en.wikipedia.org/wiki/Artifact_(archaeology)> ;
   skos:definition "An object made (manufactured, shaped, modified) by a human being, or precursor hominid. Include a set of pieces belonging originally to a single object and treated as a single specimen."@en ;
   skos:inScheme spec:specimentypevocabulary ;
@@ -115,7 +115,7 @@ spec:fossil
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;
   rdfs:label "Fossil"@en ;
-  skos:broader spec:physicalspecimen ;
+  skos:broader spec:nonbiologicsolidobject ;
   skos:definition "Specimen is the remains of one or more organisms preserved in rock; includes whole body, body parts (usually bone or shell), and trace fossils. An organism or organism part becomes a fossil when it has undergone some fossilization process that generally entails physical and chemical changes akin to diagenesis in a sedimentary rock. Trace fossils are manifestations of biologic activity preserved in a rock body (typically sedimentary), without included preserved body parts."@en ;
   skos:exactMatch <http://sweet.jpl.nasa.gov/2.3/matrRock.owl#Fossil> ;
   skos:exactMatch <https://en.wikipedia.org/wiki/Fossil> ;
@@ -131,6 +131,13 @@ spec:genericaggregation
   skos:definition "An aggregate specimen that is not biogenic or composed of anthropogenic material fragments.  Examples: loose soil or sediment (e.g. in a bag), rock chips, particulate filtrate or precipitate; rock powders."@en ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Aggregation"@en ;
+.
+spec:nonbiologicsolidobject
+  rdf:type skos:Concept ;
+  rdfs:label "Non biologic solid object"@en ;
+  skos:broader spec:physicalspecimen ;
+  skos:definition "Individual solid object, not formed directly by or part of a living organism"@en ;
+  skos:prefLabel "Non biologic solid object"@en ;
 .
 spec:organismpart
   rdf:type owl:NamedIndividual ;
@@ -158,8 +165,8 @@ spec:othersolidobject
   rdfs:label "Other solid object"@en ;
   skos:broadMatch <http://purl.obolibrary.org/obo/BFO_0000030> ;
   skos:broadMatch <http://semanticscience.org/resource/SIO_000776> ;
-  skos:broader spec:physicalspecimen ;
-  skos:definition "Single piece of material not one of the other types, e.g. rock specimen, mineral specimen, core. Ice and permafrost are considered solid materials."@en ;
+  skos:broader spec:nonbiologicsolidobject ;
+  skos:definition "Single piece of material not one of the other types." ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Other solid object"@en ;
   skos:relatedMatch <http://purl.obolibrary.org/obo/BFO_0000030> ;
@@ -190,6 +197,14 @@ spec:slurrybiomeaggregation
   skos:definition "a material that consists of mixed organic and inorganic material, including whole organisms and organism fragments."@en ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Slurry biome aggregation"@en ;
+.
+spec:solidmaterialspecimen
+  rdf:type skos:Concept ;
+  rdfs:label "Solid material specimen"@en ;
+  skos:broader spec:nonbiologicsolidobject ;
+  skos:definition "Individual solid object, not formed directly by or part of a living organism, that is representative of some material."@en ;
+  skos:note "e.g. a rock or mineral specimen, a specimen of some manufactured material, a meteorite. Ice and permafrost are considered solid materials. {@en}"@en ;
+  skos:prefLabel "Solid material specimen"@en ;
 .
 spec:specimentypevocabulary
   rdf:type owl:NamedIndividual ;

--- a/src/specimentype.ttl
+++ b/src/specimentype.ttl
@@ -65,7 +65,7 @@ spec:artifact
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;
   rdfs:label "Artifact"@en ;
-  skos:broader spec:nonbiologicsolidobject ;
+  skos:broader spec:physicalspecimen ;
   skos:closeMatch <https://en.wikipedia.org/wiki/Artifact_(archaeology)> ;
   skos:definition "An object made (manufactured, shaped, modified) by a human being, or precursor hominid. Include a set of pieces belonging originally to a single object and treated as a single specimen."@en ;
   skos:inScheme spec:specimentypevocabulary ;
@@ -123,8 +123,8 @@ spec:fossil
   rdf:type owl:NamedIndividual ;
   rdf:type skos:Concept ;
   rdfs:label "Fossil"@en ;
-  skos:broader spec:nonbiologicsolidobject ;
-  skos:definition "Specimen is the remains of one or more organisms preserved in rock; includes whole body, body parts (usually bone or shell), and trace fossils. An organism or organism part becomes a fossil when it has undergone some fossilization process that generally entails physical and chemical changes akin to diagenesis in a sedimentary rock. Includes trace fossils, which are manifestations of biologic activity preserved in a rock body (typically sedimentary), without included preserved body parts."@en ;
+  skos:broader spec:physicalspecimen ;
+  skos:definition "Specimen is the remains of one or more organisms preserved in rock; includes whole body, body parts (usually bone or shell), and trace fossils. An organism or organism part becomes a fossil when it has undergone some fossilization process that generally entails physical and chemical changes akin to diagenesis in a sedimentary rock. Trace fossils are manifestations of biologic activity preserved in a rock body (typically sedimentary), without included preserved body parts."@en ;
   skos:exactMatch <http://sweet.jpl.nasa.gov/2.3/matrRock.owl#Fossil> ;
   skos:exactMatch <https://en.wikipedia.org/wiki/Fossil> ;
   skos:inScheme spec:specimentypevocabulary ;
@@ -139,13 +139,6 @@ spec:genericaggregation
   skos:definition "An aggregate specimen that is not biogenic or composed of anthropogenic material fragments.  Examples: loose soil or sediment (e.g. in a bag), rock chips, particulate filtrate or precipitate; rock powders."@en ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Aggregation"@en ;
-.
-spec:nonbiologicsolidobject
-  rdf:type skos:Concept ;
-  rdfs:label "Non biologic solid object"@en ;
-  skos:broader spec:physicalspecimen ;
-  skos:definition "Individual solid object, not formed directly by or part of a living organism"@en ;
-  skos:prefLabel "Non biologic solid object"@en ;
 .
 spec:organismpart
   rdf:type owl:NamedIndividual ;
@@ -173,8 +166,8 @@ spec:othersolidobject
   rdfs:label "Other solid object"@en ;
   skos:broadMatch <http://purl.obolibrary.org/obo/BFO_0000030> ;
   skos:broadMatch <http://semanticscience.org/resource/SIO_000776> ;
-  skos:broader spec:nonbiologicsolidobject ;
-  skos:definition "Single piece of material not one of the other types." ;
+  skos:broader spec:physicalspecimen ;
+  skos:definition "Single piece of material not one of the other types, e.g. rock specimen, mineral specimen, core. Ice and permafrost are considered solid materials."@en ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Other solid object"@en ;
   skos:relatedMatch <http://purl.obolibrary.org/obo/BFO_0000030> ;
@@ -205,14 +198,6 @@ spec:slurrybiomeaggregation
   skos:definition "a material that consists of mixed organic and inorganic material, including whole organisms and organism fragments."@en ;
   skos:inScheme spec:specimentypevocabulary ;
   skos:prefLabel "Slurry biome aggregation"@en ;
-.
-spec:solidmaterialspecimen
-  rdf:type skos:Concept ;
-  rdfs:label "Solid material specimen"@en ;
-  skos:broader spec:nonbiologicsolidobject ;
-  skos:definition "Individual solid object, not formed directly by or part of a living organism, that is representative of some material."@en ;
-  skos:note "e.g. a rock or mineral specimen, a specimen of some manufactured material, a meteorite. Ice and permafrost are considered solid materials. {@en}"@en ;
-  skos:prefLabel "Solid material specimen"@en ;
 .
 spec:specimentypevocabulary
   rdf:type owl:NamedIndividual ;

--- a/src/specimentype.ttl
+++ b/src/specimentype.ttl
@@ -6,11 +6,18 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix spec: <https://w3id.org/isample/vocabulary/specimentype/0.9/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+<AWDID:2004562>
+  rdf:type schema:Grant ;
+  schema:funder <https://ror.org/04nh1dc89> ;
+  schema:name "Collaborative Research: Frameworks: Internet of Samples: Toward an Interdisciplinary Cyberinfrastructure for Material Samples" ;
+  schema:url "https://nsf.gov/awardsearch/showAward?AWD_ID=2004562" ;
+.
 dct:created
   rdf:type owl:AnnotationProperty ;
 .
@@ -62,6 +69,7 @@ spec:artifact
   skos:closeMatch <https://en.wikipedia.org/wiki/Artifact_(archaeology)> ;
   skos:definition "An object made (manufactured, shaped, modified) by a human being, or precursor hominid. Include a set of pieces belonging originally to a single object and treated as a single specimen."@en ;
   skos:inScheme spec:specimentypevocabulary ;
+  skos:note "A sample is classified as an artifact if it is intended to represent the manufactured item.  For example, core, thin section, peel, glass slide smear are products of human manufacture, but are intended to represent materials or biological specimens."@en ;
   skos:prefLabel "Artifact"@en ;
 .
 spec:biologicalspecimen
@@ -116,7 +124,7 @@ spec:fossil
   rdf:type skos:Concept ;
   rdfs:label "Fossil"@en ;
   skos:broader spec:nonbiologicsolidobject ;
-  skos:definition "Specimen is the remains of one or more organisms preserved in rock; includes whole body, body parts (usually bone or shell), and trace fossils. An organism or organism part becomes a fossil when it has undergone some fossilization process that generally entails physical and chemical changes akin to diagenesis in a sedimentary rock. Trace fossils are manifestations of biologic activity preserved in a rock body (typically sedimentary), without included preserved body parts."@en ;
+  skos:definition "Specimen is the remains of one or more organisms preserved in rock; includes whole body, body parts (usually bone or shell), and trace fossils. An organism or organism part becomes a fossil when it has undergone some fossilization process that generally entails physical and chemical changes akin to diagenesis in a sedimentary rock. Includes trace fossils, which are manifestations of biologic activity preserved in a rock body (typically sedimentary), without included preserved body parts."@en ;
   skos:exactMatch <http://sweet.jpl.nasa.gov/2.3/matrRock.owl#Fossil> ;
   skos:exactMatch <https://en.wikipedia.org/wiki/Fossil> ;
   skos:inScheme spec:specimentypevocabulary ;
@@ -221,8 +229,10 @@ spec:specimentypevocabulary
   skos:historyNote "2022-01-07 SMR Change base URI to https://w3id.org/isample/vocabulary/, setting up resolution using w3id. Make the conceptScheme and ontology. Add Dublin core imports."@en ;
   skos:historyNote "2022-03-11 SMR change definitions from rdfs:comment to skos:definition. Minor fixes in definitions. Add skos matches to URIs from other vocabularies."@en ;
   skos:historyNote "2022-09-30 SMR per https://github.com/isamplesorg/metadata/issues/109, change specimen to sample in vocabulary names and labels. Add 'Slurry biome aggregation' and 'Bundle biome aggregation' (github issue 110). Rename 'liquid or gas' sample type to 'fluid in container' (github issue 108)."@en ;
-  skos:note "The material sample type is intended to be orthogonal to material type and sampled feature, but of course there are some strong dependencies between the categories.  The material sample type is mostly determined by the nature of the sample object (solid, fluid, aggregate...), what kind of containment is necessary, and by the genetic origin of the material or object. There is overlap between some of the classes-- Research products might be solid objects or aggregations. Whole organisms, Fossils and Artifacts are typically solid objects. Multiple categories can be assigned to a sample, or one aspect can be chosen as pre-eminent."@en ;
+  skos:historyNote "2023-07-27 SMR modify base specimen type vocabulary, add 'Non biologic solid object'  change broader relations in this vocab to use that as parent class where appropriate.  Intention is a specimen category for solid objects that are not biologic; this subsumes 'Fossil' and 'Artifact', but excludes living organism, their parts and products. Obviously there is some overlap with Research specimens."@en ;
+  skos:note "The material sample type is intended to be orthogonal to material type and sampled feature, but there are dependencies between some categories.  The material sample type is mostly determined by the nature of the sample object (solid, fluid, aggregate...), what kind of containment is necessary, and by the genetic origin of the material or object. There is overlap between some of the classes-- Research products might be solid objects or aggregations. Whole organisms, Fossils and Artifacts are typically solid objects. Multiple categories can be assigned to a sample, or one aspect can be chosen as pre-eminent."@en ;
   skos:prefLabel "iSamples Material Sample Type Vocabulary"@en ;
+  schema:funding <AWDID:2004562> ;
 .
 spec:wholeorganism
   rdf:type owl:NamedIndividual ;


### PR DESCRIPTION
this follows https://github.com/isamplesorg/vocabularies/pull/6, conflicts should be resolved in #6 is pulled.

Other vocab cleanup in vocabulary extensions.
add funding (use schema.org properties), 
add missing inscheme and topConcept
move source information in to dcterms:source
fix some notes.
remove unnecessary skos:broader on Fragmental_igneous_Rock